### PR TITLE
[Feature] 페스티벌, 리뷰, 댓글 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/sparta/lafesta/comment/controller/CommentController.java
+++ b/src/main/java/com/sparta/lafesta/comment/controller/CommentController.java
@@ -65,4 +65,24 @@ public class CommentController {
         commentService.deleteComment(commentId, userDetails.getUser());
         return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "댓글 삭제 완료"));
     }
+
+    @PostMapping("/festivals/{festivalId}/reviews/{reviewId}/comments/{commentId}/likes")
+    @Operation(summary = "페스티벌 리뷰 댓글 좋아요 추가", description = "페스티벌 리뷰 댓글에 좋아요를 추가합니다.")
+    public ResponseEntity<ApiResponseDto> createCommentLike(
+            @Parameter(name = "commentId", description = "좋아요를 추가할 댓글의 id", in = ParameterIn.PATH) @PathVariable Long commentId,
+            @Parameter(description = "권한 확인을 위해 필요한 User 정보")@AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        CommentResponseDto result = commentService.createCommentLike(commentId, userDetails.getUser());
+        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.CREATED.value(), "좋아요를 추가했습니다.\n좋아요 수: " + result.getLikeCnt()));
+    }
+
+    @DeleteMapping("/festivals/{festivalId}/reviews/{reviewId}/comments/{commentId}/likes-cancel")
+    @Operation(summary = "페스티벌 리뷰 댓글 좋아요 취소", description = "페스티벌 리뷰 댓글에 좋아요를 취소합니다.")
+    public ResponseEntity<ApiResponseDto> deleteCommentLike(
+            @Parameter(name = "commentId", description = "좋아요를 취소할 댓글의 id", in = ParameterIn.PATH) @PathVariable Long commentId,
+            @Parameter(description = "권한 확인을 위해 필요한 User 정보")@AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        CommentResponseDto result = commentService.deleteCommentLike(commentId, userDetails.getUser());
+        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "좋아요를 취소했습니다.\n좋아요 수: " + result.getLikeCnt()));
+    }
 }

--- a/src/main/java/com/sparta/lafesta/comment/controller/CommentController.java
+++ b/src/main/java/com/sparta/lafesta/comment/controller/CommentController.java
@@ -73,7 +73,7 @@ public class CommentController {
             @Parameter(description = "권한 확인을 위해 필요한 User 정보")@AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
         CommentResponseDto result = commentService.createCommentLike(commentId, userDetails.getUser());
-        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.CREATED.value(), "좋아요를 추가했습니다.\n좋아요 수: " + result.getLikeCnt()));
+        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.CREATED.value(), "좋아요를 추가했습니다. 좋아요 수: " + result.getLikeCnt()));
     }
 
     @DeleteMapping("/festivals/{festivalId}/reviews/{reviewId}/comments/{commentId}/likes-cancel")
@@ -83,6 +83,6 @@ public class CommentController {
             @Parameter(description = "권한 확인을 위해 필요한 User 정보")@AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
         CommentResponseDto result = commentService.deleteCommentLike(commentId, userDetails.getUser());
-        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "좋아요를 취소했습니다.\n좋아요 수: " + result.getLikeCnt()));
+        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "좋아요를 취소했습니다. 좋아요 수: " + result.getLikeCnt()));
     }
 }

--- a/src/main/java/com/sparta/lafesta/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/sparta/lafesta/comment/dto/CommentResponseDto.java
@@ -10,6 +10,7 @@ public class CommentResponseDto {
     private String reviewTitle;
     private String userNickname;
     private String content;
+    private int likeCnt;
 
     public CommentResponseDto(Comment comment) {
         this.id = comment.getId();
@@ -17,5 +18,6 @@ public class CommentResponseDto {
         this.reviewTitle = comment.getReview().getTitle();
         this.userNickname = comment.getUser().getNickname();
         this.content = comment.getContent();
+        this.likeCnt = comment.getCommentLikes().size();
     }
 }

--- a/src/main/java/com/sparta/lafesta/comment/entity/Comment.java
+++ b/src/main/java/com/sparta/lafesta/comment/entity/Comment.java
@@ -2,6 +2,7 @@ package com.sparta.lafesta.comment.entity;
 
 import com.sparta.lafesta.comment.dto.CommentRequestDto;
 import com.sparta.lafesta.common.entity.Timestamped;
+import com.sparta.lafesta.like.commentLike.entity.CommentLike;
 import com.sparta.lafesta.review.entity.Review;
 import com.sparta.lafesta.user.entity.User;
 import jakarta.persistence.*;
@@ -9,6 +10,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Builder
 @AllArgsConstructor
@@ -31,6 +35,9 @@ public class Comment extends Timestamped {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reviewId", nullable = false)
     private Review review;
+
+    @OneToMany(mappedBy = "comment", orphanRemoval = true)
+    private List<CommentLike> commentLikes = new ArrayList<>();
 
     public Comment(Review review, CommentRequestDto requestDto, User user) {
         this.review = review;

--- a/src/main/java/com/sparta/lafesta/comment/entity/Comment.java
+++ b/src/main/java/com/sparta/lafesta/comment/entity/Comment.java
@@ -6,17 +6,14 @@ import com.sparta.lafesta.like.commentLike.entity.CommentLike;
 import com.sparta.lafesta.review.entity.Review;
 import com.sparta.lafesta.user.entity.User;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Getter
 @Table(name = "comments")

--- a/src/main/java/com/sparta/lafesta/comment/service/CommentService.java
+++ b/src/main/java/com/sparta/lafesta/comment/service/CommentService.java
@@ -8,31 +8,51 @@ import java.util.List;
 
 public interface CommentService {
     /**
-     * @param reviewId
-     * @param requestDto
-     * @param user
+     * 댓글 생성
+     * @param reviewId 댓글을 생성할 리뷰의 id
+     * @param requestDto 댓글 정보
+     * @param user 권한 확인
      * @return 댓글 추가 결과
      */
     CommentResponseDto createComment(Long reviewId, CommentRequestDto requestDto, User user);
 
     /**
-     * @param reviewId
-     * @param user
+     * 전체 댓글 조회
+     * @param reviewId 전체 댓글을 조회할 리뷰의 id
+     * @param user 권한 확인
      * @return 전체 댓글 조회 결과
      */
     List<CommentResponseDto> selectComments(Long reviewId, User user);
 
     /**
-     * @param commentId
-     * @param requestDto
-     * @param user
-     * @return
+     * 댓글 수정
+     * @param commentId 수정할 댓글의 id
+     * @param requestDto 댓글 수정 정보
+     * @param user 권한 확인
+     * @return 댓글 수정 결과
      */
     CommentResponseDto modifyComment(Long commentId, CommentRequestDto requestDto, User user);
 
     /**
-     * @param commentId
-     * @param user
+     * 댓글 삭제
+     * @param commentId 수정할 댓글의 id
+     * @param user 권한 확인
      */
     void deleteComment(Long commentId, User user);
+
+    /**
+     * 선택한 댓글 좋아요 추가
+     * @param commentId 좋아요 추가할 댓글의 id
+     * @param user 권한 확인
+     * @return 좋아요 추가 결과
+     */
+    CommentResponseDto createCommentLike(Long commentId, User user);
+
+    /**
+     * 선택한 댓글 좋아요 취소
+     * @param commentId 좋아요 취소할 댓글의 id
+     * @param user 권한 확인
+     * @return 좋아요 취소 결과
+     */
+    CommentResponseDto deleteCommentLike(Long commentId, User user);
 }

--- a/src/main/java/com/sparta/lafesta/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/sparta/lafesta/comment/service/CommentServiceImpl.java
@@ -4,6 +4,8 @@ import com.sparta.lafesta.comment.dto.CommentRequestDto;
 import com.sparta.lafesta.comment.dto.CommentResponseDto;
 import com.sparta.lafesta.comment.entity.Comment;
 import com.sparta.lafesta.comment.repository.CommentRepository;
+import com.sparta.lafesta.like.commentLike.entity.CommentLike;
+import com.sparta.lafesta.like.commentLike.repository.CommentLikeRepository;
 import com.sparta.lafesta.review.entity.Review;
 import com.sparta.lafesta.review.service.ReviewServiceImpl;
 import com.sparta.lafesta.user.entity.User;
@@ -19,6 +21,7 @@ import java.util.stream.Collectors;
 public class CommentServiceImpl implements CommentService {
     private final CommentRepository commentRepository;
     private final ReviewServiceImpl reviewService;
+    private final CommentLikeRepository commentLikeRepository;
 
     // 댓글 생성
     @Override
@@ -60,10 +63,45 @@ public class CommentServiceImpl implements CommentService {
         commentRepository.delete(comment);
     }
 
+    // 댓글 좋아요 추가
+    @Override
+    @Transactional
+    public CommentResponseDto createCommentLike(Long commentId, User user) {
+        Comment comment = findComment(commentId);
+        // 좋아요를 이미 누른 경우 오류 반환
+        if (findCommentLike(user, comment) != null) {
+            throw new IllegalArgumentException("좋아요를 이미 누르셨습니다.");
+        }
+        // 오류가 나지 않을 경우 해당 리뷰에 좋아요 추가
+        commentLikeRepository.save(new CommentLike(user, comment));
+
+        return new CommentResponseDto(comment);
+    }
+
+    // 리뷰 좋아요 취소
+    @Override
+    @Transactional
+    public CommentResponseDto deleteCommentLike(Long commentId, User user) {
+        Comment comment = findComment(commentId);
+        // 좋아요를 누르지 않은 경우 오류 반환
+        if (findCommentLike(user, comment) == null) {
+            throw new IllegalArgumentException("좋아요를 누르시지 않았습니다.");
+        }
+        // 오류가 나지 않을 경우 해당 페스티벌에 좋아요 취소
+        commentLikeRepository.delete(findCommentLike(user, comment));
+
+        return new CommentResponseDto(comment);
+    }
+
     // 댓글 id로 댓글 찾기
     public Comment findComment(Long commentId) {
         return commentRepository.findById(commentId).orElseThrow(() ->
                 new IllegalArgumentException("선택한 댓글은 존재하지 않습니다.")
         );
+    }
+
+    // 리뷰와 사용자로 좋아요 찾기
+    private CommentLike findCommentLike(User user, Comment comment) {
+        return commentLikeRepository.findByUserAndComment(user, comment).orElse(null);
     }
 }

--- a/src/main/java/com/sparta/lafesta/festival/controller/FestivalController.java
+++ b/src/main/java/com/sparta/lafesta/festival/controller/FestivalController.java
@@ -79,7 +79,7 @@ public class FestivalController {
             @Parameter(description = "권한 확인을 위해 필요한 User 정보")@AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
         FestivalResponseDto result = festivalService.createFestivalLike(festivalId, userDetails.getUser());
-        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.CREATED.value(), "좋아요를 추가했습니다.\n좋아요 수: " + result.getLikeCnt()));
+        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.CREATED.value(), "좋아요를 추가했습니다. 좋아요 수: " + result.getLikeCnt()));
     }
 
     @DeleteMapping("/festivals/{festivalId}/likes-cancel")
@@ -89,6 +89,6 @@ public class FestivalController {
             @Parameter(description = "권한 확인을 위해 필요한 User 정보")@AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
         FestivalResponseDto result = festivalService.deleteFestivalLike(festivalId, userDetails.getUser());
-        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "좋아요를 취소했습니다.\n좋아요 수: " + result.getLikeCnt()));
+        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "좋아요를 취소했습니다. 좋아요 수: " + result.getLikeCnt()));
     }
 }

--- a/src/main/java/com/sparta/lafesta/festival/controller/FestivalController.java
+++ b/src/main/java/com/sparta/lafesta/festival/controller/FestivalController.java
@@ -71,4 +71,24 @@ public class FestivalController {
         festivalService.deleteFestival(festivalId, userDetails.getUser());
         return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "페스티벌 삭제 완료"));
     }
+
+    @PostMapping("/festivals/{festivalId}/likes")
+    @Operation(summary = "페스티벌 좋아요 추가", description = "페스티벌에 좋아요를 추가합니다.")
+    public ResponseEntity<ApiResponseDto> createFestivalLike(
+            @Parameter(name = "festivalId", description = "좋아요를 추가할 페스티벌의 id", in = ParameterIn.PATH) @PathVariable Long festivalId,
+            @Parameter(description = "권한 확인을 위해 필요한 User 정보")@AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        FestivalResponseDto result = festivalService.createFestivalLike(festivalId, userDetails.getUser());
+        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.CREATED.value(), "좋아요를 추가했습니다.\n좋아요 수: " + result.getLikeCnt()));
+    }
+
+    @DeleteMapping("/festivals/{festivalId}/likes-cancel")
+    @Operation(summary = "페스티벌 좋아요 취소", description = "페스티벌에 좋아요를 취소합니다.")
+    public ResponseEntity<ApiResponseDto> deleteFestivalLike(
+            @Parameter(name = "festivalId", description = "좋아요를 취소할 페스티벌의 id", in = ParameterIn.PATH) @PathVariable Long festivalId,
+            @Parameter(description = "권한 확인을 위해 필요한 User 정보")@AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        FestivalResponseDto result = festivalService.deleteFestivalLike(festivalId, userDetails.getUser());
+        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "좋아요를 취소했습니다.\n좋아요 수: " + result.getLikeCnt()));
+    }
 }

--- a/src/main/java/com/sparta/lafesta/festival/dto/FestivalResponseDto.java
+++ b/src/main/java/com/sparta/lafesta/festival/dto/FestivalResponseDto.java
@@ -19,6 +19,7 @@ public class FestivalResponseDto {
     private LocalDateTime reservationOpenDate;
     private String officialLink;
     private List<ReviewResponseDto> reviews;
+    private int likeCnt;
 
     public FestivalResponseDto(Festival festival) {
         this.id = festival.getId();
@@ -31,5 +32,6 @@ public class FestivalResponseDto {
         this.officialLink = festival.getOfficialLink();
         this.reviews = festival.getReviews().stream().
                 map(ReviewResponseDto::new).collect(Collectors.toList());
+        this.likeCnt = festival.getFestivalLikes().size();
     }
 }

--- a/src/main/java/com/sparta/lafesta/festival/entity/Festival.java
+++ b/src/main/java/com/sparta/lafesta/festival/entity/Festival.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Getter
 @Setter

--- a/src/main/java/com/sparta/lafesta/festival/entity/Festival.java
+++ b/src/main/java/com/sparta/lafesta/festival/entity/Festival.java
@@ -2,6 +2,7 @@ package com.sparta.lafesta.festival.entity;
 
 import com.sparta.lafesta.common.entity.Timestamped;
 import com.sparta.lafesta.festival.dto.FestivalRequestDto;
+import com.sparta.lafesta.like.festivalLike.entity.FestivalLike;
 import com.sparta.lafesta.review.entity.Review;
 import jakarta.persistence.*;
 import lombok.*;
@@ -45,6 +46,9 @@ public class Festival extends Timestamped {
 
     @OneToMany(mappedBy = "festival", orphanRemoval = true)
     private List<Review> reviews = new ArrayList<>();
+
+    @OneToMany(mappedBy = "festival", orphanRemoval = true)
+    private List<FestivalLike> festivalLikes = new ArrayList<>();
 
     public Festival(FestivalRequestDto requestDto) {
         this.title = requestDto.getTitle();

--- a/src/main/java/com/sparta/lafesta/festival/service/FestivalService.java
+++ b/src/main/java/com/sparta/lafesta/festival/service/FestivalService.java
@@ -8,35 +8,56 @@ import java.util.List;
 
 public interface FestivalService {
     /**
-     * @param requestDto
-     * @param user
+     * 페스티벌 생성
+     * @param requestDto 생성할 페스티벌의 정보
+     * @param user 권한 확인
      * @return 페스티벌 추가 결과
      */
     FestivalResponseDto createFestival(FestivalRequestDto requestDto, User user);
 
     /**
+     * 전체 페스티벌 조회
      * @return 전체 페스티벌 조회 결과
      */
     List<FestivalResponseDto> selectFestivals();
 
     /**
-     * @param festivalId
-     * @param user
+     * 페스티벌 상세 조회
+     * @param festivalId 조회할 페스티벌의 id
+     * @param user 권한 확인
      * @return 페스티벌 상세 조회 결과
      */
     FestivalResponseDto selectFestival(Long festivalId, User user);
 
     /**
-     * @param festivalId
-     * @param requestDto
-     * @param user
-     * @return
+     * 페스티벌 수정
+     * @param festivalId 수정할 페스티벌의 id
+     * @param requestDto 수정할 정보
+     * @param user 권한 확인
+     * @return 페스티벌 수정 결과
      */
     FestivalResponseDto modifyFestival(Long festivalId, FestivalRequestDto requestDto, User user);
 
     /**
-     * @param festivalId
-     * @param user
+     * 페스티벌 삭제
+     * @param festivalId 삭제할 페스티벌의 id
+     * @param user 권한 확인
      */
     void deleteFestival(Long festivalId, User user);
+
+    /**
+     * 선택한 페스티벌 좋아요 추가
+     * @param festivalId 좋아요 추가할 페스티벌의 id
+     * @param user 권한 확인
+     * @return 좋아요 추가 결과
+     */
+    FestivalResponseDto createFestivalLike(Long festivalId, User user);
+
+    /**
+     * 선택한 페스티벌 좋아요 취소
+     * @param festivalId 좋아요 취소할 페스티벌의 id
+     * @param user 권한 확인
+     * @return 좋아요 취소 결과
+     */
+    FestivalResponseDto deleteFestivalLike(Long festivalId, User user);
 }

--- a/src/main/java/com/sparta/lafesta/festival/service/FestivalServiceImpl.java
+++ b/src/main/java/com/sparta/lafesta/festival/service/FestivalServiceImpl.java
@@ -8,8 +8,10 @@ import com.sparta.lafesta.like.festivalLike.entity.FestivalLike;
 import com.sparta.lafesta.like.festivalLike.repository.FestivalLikeRepository;
 import com.sparta.lafesta.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,6 +21,8 @@ import java.util.stream.Collectors;
 public class FestivalServiceImpl implements FestivalService {
     private final FestivalRepository festivalRepository;
     private final FestivalLikeRepository festivalLikeRepository;
+    @Autowired
+    private TransactionTemplate transactionTemplate;
 
     // 페스티벌 등록
     @Override
@@ -82,17 +86,25 @@ public class FestivalServiceImpl implements FestivalService {
 
     // 페스티벌 좋아요 취소
     @Override
-    @Transactional
     public FestivalResponseDto deleteFestivalLike(Long festivalId, User user) {
-        Festival festival = findFestival(festivalId);
-        // 좋아요를 누르지 않은 경우 오류 반환
-        if (findFestivalLike(user, festival) == null) {
-            throw new IllegalArgumentException("좋아요를 누르시지 않았습니다.");
-        }
-        // 오류가 나지 않을 경우 해당 페스티벌에 좋아요 취소
-        festivalLikeRepository.delete(findFestivalLike(user, festival));
+        FestivalResponseDto response = transactionTemplate.execute(status -> {
+            Festival festival = findFestival(festivalId);
+            // 좋아요를 누르지 않은 경우 오류 반환
+            if (findFestivalLike(user, festival) == null) {
+                throw new IllegalArgumentException("좋아요를 누르시지 않았습니다.");
+            }
+            // 오류가 나지 않을 경우 해당 페스티벌에 좋아요 취소
+            festivalLikeRepository.delete(findFestivalLike(user, festival));
 
-        return new FestivalResponseDto(festival);
+            // 여기에서 커밋을 수행 (트랜잭션 내에서 커밋 또는 롤백을 수행할 수 있음)
+            status.flush();
+
+            // FestivalResponseDto 생성 후 반환
+            return new FestivalResponseDto(festival);
+        });
+
+        // 위에서 커밋이 수행되었으므로 FestivalResponseDto에서 새로운 likeCnt를 가져올 수 있음
+        return response;
     }
 
     // 페스티벌 id로 페스티벌 찾기

--- a/src/main/java/com/sparta/lafesta/festival/service/FestivalServiceImpl.java
+++ b/src/main/java/com/sparta/lafesta/festival/service/FestivalServiceImpl.java
@@ -4,6 +4,8 @@ import com.sparta.lafesta.festival.dto.FestivalRequestDto;
 import com.sparta.lafesta.festival.dto.FestivalResponseDto;
 import com.sparta.lafesta.festival.entity.Festival;
 import com.sparta.lafesta.festival.repository.FestivalRepository;
+import com.sparta.lafesta.like.festivalLike.entity.FestivalLike;
+import com.sparta.lafesta.like.festivalLike.repository.FestivalLikeRepository;
 import com.sparta.lafesta.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +18,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class FestivalServiceImpl implements FestivalService {
     private final FestivalRepository festivalRepository;
+    private final FestivalLikeRepository festivalLikeRepository;
 
     // 페스티벌 등록
     @Override
@@ -62,10 +65,45 @@ public class FestivalServiceImpl implements FestivalService {
         festivalRepository.delete(festival);
     }
 
+    // 페스티벌 좋아요 추가
+    @Override
+    @Transactional
+    public FestivalResponseDto createFestivalLike(Long festivalId, User user) {
+        Festival festival = findFestival(festivalId);
+        // 좋아요를 이미 누른 경우 오류 반환
+        if (findFestivalLike(user, festival) != null) {
+            throw new IllegalArgumentException("좋아요를 이미 누르셨습니다.");
+        }
+        // 오류가 나지 않을 경우 해당 페스티벌에 좋아요 추가
+        festivalLikeRepository.save(new FestivalLike(user, festival));
+
+        return new FestivalResponseDto(festival);
+    }
+
+    // 페스티벌 좋아요 취소
+    @Override
+    @Transactional
+    public FestivalResponseDto deleteFestivalLike(Long festivalId, User user) {
+        Festival festival = findFestival(festivalId);
+        // 좋아요를 누르지 않은 경우 오류 반환
+        if (findFestivalLike(user, festival) == null) {
+            throw new IllegalArgumentException("좋아요를 누르시지 않았습니다.");
+        }
+        // 오류가 나지 않을 경우 해당 페스티벌에 좋아요 취소
+        festivalLikeRepository.delete(findFestivalLike(user, festival));
+
+        return new FestivalResponseDto(festival);
+    }
+
     // 페스티벌 id로 페스티벌 찾기
     public Festival findFestival(Long festivalId) {
         return festivalRepository.findById(festivalId).orElseThrow(() ->
                 new IllegalArgumentException("선택한 페스티벌은 존재하지 않습니다.")
         );
+    }
+
+    // 페스티벌과 사용자로 좋아요 찾기
+    private FestivalLike findFestivalLike(User user, Festival festival) {
+        return festivalLikeRepository.findByUserAndFestival(user, festival).orElse(null);
     }
 }

--- a/src/main/java/com/sparta/lafesta/like/commentLike/entity/CommentLike.java
+++ b/src/main/java/com/sparta/lafesta/like/commentLike/entity/CommentLike.java
@@ -1,4 +1,31 @@
 package com.sparta.lafesta.like.commentLike.entity;
 
+import com.sparta.lafesta.comment.entity.Comment;
+import com.sparta.lafesta.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "commentLike")
 public class CommentLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "commentId")
+    private Comment comment;
+
+    public CommentLike(User user, Comment comment) {
+        this.user = user;
+        this.comment = comment;
+    }
 }

--- a/src/main/java/com/sparta/lafesta/like/commentLike/entity/CommentLike.java
+++ b/src/main/java/com/sparta/lafesta/like/commentLike/entity/CommentLike.java
@@ -3,11 +3,12 @@ package com.sparta.lafesta.like.commentLike.entity;
 import com.sparta.lafesta.comment.entity.Comment;
 import com.sparta.lafesta.user.entity.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "commentLike")
 public class CommentLike {

--- a/src/main/java/com/sparta/lafesta/like/commentLike/entity/CommentLike.java
+++ b/src/main/java/com/sparta/lafesta/like/commentLike/entity/CommentLike.java
@@ -1,0 +1,4 @@
+package com.sparta.lafesta.like.commentLike.entity;
+
+public class CommentLike {
+}

--- a/src/main/java/com/sparta/lafesta/like/commentLike/repository/CommentLikeRepository.java
+++ b/src/main/java/com/sparta/lafesta/like/commentLike/repository/CommentLikeRepository.java
@@ -1,4 +1,14 @@
 package com.sparta.lafesta.like.commentLike.repository;
 
-public interface CommentLikeRepository {
+import com.sparta.lafesta.comment.entity.Comment;
+import com.sparta.lafesta.like.commentLike.entity.CommentLike;
+import com.sparta.lafesta.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CommentLikeRepository extends JpaRepository <CommentLike, Long> {
+    Optional<CommentLike> findByUserAndComment(User user, Comment comment);
 }

--- a/src/main/java/com/sparta/lafesta/like/commentLike/repository/CommentLikeRepository.java
+++ b/src/main/java/com/sparta/lafesta/like/commentLike/repository/CommentLikeRepository.java
@@ -1,0 +1,4 @@
+package com.sparta.lafesta.like.commentLike.repository;
+
+public interface CommentLikeRepository {
+}

--- a/src/main/java/com/sparta/lafesta/like/festivalLike/entity/FestivalLike.java
+++ b/src/main/java/com/sparta/lafesta/like/festivalLike/entity/FestivalLike.java
@@ -3,11 +3,12 @@ package com.sparta.lafesta.like.festivalLike.entity;
 import com.sparta.lafesta.festival.entity.Festival;
 import com.sparta.lafesta.user.entity.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "festivalLike")
 public class FestivalLike {

--- a/src/main/java/com/sparta/lafesta/like/festivalLike/entity/FestivalLike.java
+++ b/src/main/java/com/sparta/lafesta/like/festivalLike/entity/FestivalLike.java
@@ -1,4 +1,31 @@
 package com.sparta.lafesta.like.festivalLike.entity;
 
+import com.sparta.lafesta.festival.entity.Festival;
+import com.sparta.lafesta.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "festivalLike")
 public class FestivalLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "festivalId")
+    private Festival festival;
+
+    public FestivalLike(User user, Festival festival) {
+        this.user = user;
+        this.festival = festival;
+    }
 }

--- a/src/main/java/com/sparta/lafesta/like/festivalLike/entity/FestivalLike.java
+++ b/src/main/java/com/sparta/lafesta/like/festivalLike/entity/FestivalLike.java
@@ -1,0 +1,4 @@
+package com.sparta.lafesta.like.festivalLike.entity;
+
+public class FestivalLike {
+}

--- a/src/main/java/com/sparta/lafesta/like/festivalLike/repository/FestivalLikeRepository.java
+++ b/src/main/java/com/sparta/lafesta/like/festivalLike/repository/FestivalLikeRepository.java
@@ -1,0 +1,4 @@
+package com.sparta.lafesta.like.festivalLike.repository;
+
+public interface FestivalLikeRepository {
+}

--- a/src/main/java/com/sparta/lafesta/like/festivalLike/repository/FestivalLikeRepository.java
+++ b/src/main/java/com/sparta/lafesta/like/festivalLike/repository/FestivalLikeRepository.java
@@ -1,4 +1,14 @@
 package com.sparta.lafesta.like.festivalLike.repository;
 
-public interface FestivalLikeRepository {
+import com.sparta.lafesta.festival.entity.Festival;
+import com.sparta.lafesta.like.festivalLike.entity.FestivalLike;
+import com.sparta.lafesta.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface FestivalLikeRepository extends JpaRepository <FestivalLike, Long> {
+    Optional<FestivalLike> findByUserAndFestival(User user, Festival festival);
 }

--- a/src/main/java/com/sparta/lafesta/like/reviewLike/entity/ReviewLike.java
+++ b/src/main/java/com/sparta/lafesta/like/reviewLike/entity/ReviewLike.java
@@ -3,11 +3,12 @@ package com.sparta.lafesta.like.reviewLike.entity;
 import com.sparta.lafesta.review.entity.Review;
 import com.sparta.lafesta.user.entity.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "reviewLike")
 public class ReviewLike {

--- a/src/main/java/com/sparta/lafesta/like/reviewLike/entity/ReviewLike.java
+++ b/src/main/java/com/sparta/lafesta/like/reviewLike/entity/ReviewLike.java
@@ -1,0 +1,4 @@
+package com.sparta.lafesta.like.reviewLike.entity;
+
+public class ReviewLike {
+}

--- a/src/main/java/com/sparta/lafesta/like/reviewLike/entity/ReviewLike.java
+++ b/src/main/java/com/sparta/lafesta/like/reviewLike/entity/ReviewLike.java
@@ -1,4 +1,31 @@
 package com.sparta.lafesta.like.reviewLike.entity;
 
+import com.sparta.lafesta.review.entity.Review;
+import com.sparta.lafesta.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "reviewLike")
 public class ReviewLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewId")
+    private Review review;
+
+    public ReviewLike(User user, Review review) {
+        this.user = user;
+        this.review = review;
+    }
 }

--- a/src/main/java/com/sparta/lafesta/like/reviewLike/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/sparta/lafesta/like/reviewLike/repository/ReviewLikeRepository.java
@@ -1,0 +1,4 @@
+package com.sparta.lafesta.like.reviewLike.repository;
+
+public interface ReviewLikeRepository {
+}

--- a/src/main/java/com/sparta/lafesta/like/reviewLike/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/sparta/lafesta/like/reviewLike/repository/ReviewLikeRepository.java
@@ -1,4 +1,14 @@
 package com.sparta.lafesta.like.reviewLike.repository;
 
-public interface ReviewLikeRepository {
+import com.sparta.lafesta.like.reviewLike.entity.ReviewLike;
+import com.sparta.lafesta.review.entity.Review;
+import com.sparta.lafesta.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ReviewLikeRepository extends JpaRepository <ReviewLike, Long> {
+    Optional<ReviewLike> findByUserAndReview (User user, Review review);
 }

--- a/src/main/java/com/sparta/lafesta/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/lafesta/review/controller/ReviewController.java
@@ -83,7 +83,7 @@ public class ReviewController {
             @Parameter(description = "권한 확인을 위해 필요한 User 정보")@AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
         ReviewResponseDto result = reviewService.createReviewLike(reviewId, userDetails.getUser());
-        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.CREATED.value(), "좋아요를 추가했습니다.\n좋아요 수: " + result.getLikeCnt()));
+        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.CREATED.value(), "좋아요를 추가했습니다. 좋아요 수: " + result.getLikeCnt()));
     }
 
     @DeleteMapping("/festivals/{festivalId}/reviews/{reviewId}/likes-cancel")
@@ -93,6 +93,6 @@ public class ReviewController {
             @Parameter(description = "권한 확인을 위해 필요한 User 정보")@AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
         ReviewResponseDto result = reviewService.deleteReviewLike(reviewId, userDetails.getUser());
-        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "좋아요를 취소했습니다.\n좋아요 수: " + result.getLikeCnt()));
+        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "좋아요를 취소했습니다. 좋아요 수: " + result.getLikeCnt()));
     }
 }

--- a/src/main/java/com/sparta/lafesta/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/lafesta/review/controller/ReviewController.java
@@ -75,4 +75,24 @@ public class ReviewController {
         reviewService.deleteReview(reviewId, userDetails.getUser());
         return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "리뷰 삭제 완료"));
     }
+
+    @PostMapping("/festivals/{festivalId}/reviews/{reviewId}/likes")
+    @Operation(summary = "페스티벌 리뷰 좋아요 추가", description = "페스티벌 리뷰에 좋아요를 추가합니다.")
+    public ResponseEntity<ApiResponseDto> createReviewLike(
+            @Parameter(name = "reviewId", description = "좋아요를 추가할 리뷰의 id", in = ParameterIn.PATH) @PathVariable Long reviewId,
+            @Parameter(description = "권한 확인을 위해 필요한 User 정보")@AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        ReviewResponseDto result = reviewService.createReviewLike(reviewId, userDetails.getUser());
+        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.CREATED.value(), "좋아요를 추가했습니다.\n좋아요 수: " + result.getLikeCnt()));
+    }
+
+    @DeleteMapping("/festivals/{festivalId}/reviews/{reviewId}/likes-cancel")
+    @Operation(summary = "페스티벌 리뷰 좋아요 취소", description = "페스티벌 리뷰에 좋아요를 취소합니다.")
+    public ResponseEntity<ApiResponseDto> deleteReviewLike(
+            @Parameter(name = "reviewId", description = "좋아요를 취소할 리뷰의 id", in = ParameterIn.PATH) @PathVariable Long reviewId,
+            @Parameter(description = "권한 확인을 위해 필요한 User 정보")@AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        ReviewResponseDto result = reviewService.deleteReviewLike(reviewId, userDetails.getUser());
+        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "좋아요를 취소했습니다.\n좋아요 수: " + result.getLikeCnt()));
+    }
 }

--- a/src/main/java/com/sparta/lafesta/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/sparta/lafesta/review/dto/ReviewResponseDto.java
@@ -15,6 +15,7 @@ public class ReviewResponseDto {
     private String title;
     private String content;
     private List<CommentResponseDto> comments;
+    private int likeCnt;
 
     public ReviewResponseDto(Review review) {
         this.id = review.getId();
@@ -24,5 +25,6 @@ public class ReviewResponseDto {
         this.content = review.getContent();
         this.comments = review.getComments().stream().
                 map(CommentResponseDto::new).collect(Collectors.toList());
+        this.likeCnt = review.getReviewLikes().size();
     }
 }

--- a/src/main/java/com/sparta/lafesta/review/entity/Review.java
+++ b/src/main/java/com/sparta/lafesta/review/entity/Review.java
@@ -7,17 +7,14 @@ import com.sparta.lafesta.like.reviewLike.entity.ReviewLike;
 import com.sparta.lafesta.review.dto.ReviewRequestDto;
 import com.sparta.lafesta.user.entity.User;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Getter
 @Table(name = "reviews")

--- a/src/main/java/com/sparta/lafesta/review/entity/Review.java
+++ b/src/main/java/com/sparta/lafesta/review/entity/Review.java
@@ -3,6 +3,7 @@ package com.sparta.lafesta.review.entity;
 import com.sparta.lafesta.comment.entity.Comment;
 import com.sparta.lafesta.common.entity.Timestamped;
 import com.sparta.lafesta.festival.entity.Festival;
+import com.sparta.lafesta.like.reviewLike.entity.ReviewLike;
 import com.sparta.lafesta.review.dto.ReviewRequestDto;
 import com.sparta.lafesta.user.entity.User;
 import jakarta.persistence.*;
@@ -41,6 +42,9 @@ public class Review extends Timestamped {
 
     @OneToMany(mappedBy = "review", orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "review", orphanRemoval = true)
+    private List<ReviewLike> reviewLikes = new ArrayList<>();
 
     public Review(Festival festival, ReviewRequestDto requestDto, User user) {
         this.festival = festival;

--- a/src/main/java/com/sparta/lafesta/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/lafesta/review/service/ReviewService.java
@@ -8,38 +8,59 @@ import java.util.List;
 
 public interface ReviewService {
     /**
-     * @param festivalId
-     * @param requestDto
-     * @param user
+     * 리뷰 생성
+     * @param festivalId 리뷰를 추가할 페스티벌의 id
+     * @param requestDto 추가할 리뷰의 정보
+     * @param user 권한 확인
      * @return 리뷰 추가 결과
      */
     ReviewResponseDto createReview(Long festivalId, ReviewRequestDto requestDto, User user);
 
     /**
-     * @param festivalId
-     * @param user
+     * 전체 리뷰 조회
+     * @param festivalId 전체 리뷰를 조회할 페스티벌의 id
+     * @param user 권한 확인
      * @return 전체 리뷰 조회 결과
      */
     List<ReviewResponseDto> selectReviews(Long festivalId, User user);
 
     /**
-     * @param reviewId
-     * @param user
+     * 리뷰 상세 조회
+     * @param reviewId 조회할 리뷰의 id
+     * @param user 권한 확인
      * @return 리뷰 상세 조회 결과
      */
     ReviewResponseDto selectReview(Long reviewId, User user);
 
     /**
-     * @param reviewId
-     * @param requestDto
-     * @param user
-     * @return
+     * 리뷰 수정
+     * @param reviewId 수정할 리뷰의 id
+     * @param requestDto 리뷰 수정할 정보
+     * @param user 권한 확인
+     * @return 리뷰 수정 결과
      */
     ReviewResponseDto modifyReview(Long reviewId, ReviewRequestDto requestDto, User user);
 
     /**
-     * @param reviewId
-     * @param user
+     * 리뷰 삭제
+     * @param reviewId 삭제할 리뷰의 id
+     * @param user 권한 확인
      */
     void deleteReview(Long reviewId, User user);
+
+    /**
+     * 선택한 리뷰 좋아요 추가
+     * @param reviewId 좋아요 추가할 리뷰의 id
+     * @param user 권한 확인
+     * @return 좋아요 추가 결과
+     */
+    ReviewResponseDto createReviewLike(Long reviewId, User user);
+
+    /**
+     * 선택한 리뷰 좋아요 취소
+     * @param reviewId 좋아요 취소할 리뷰의 id
+     * @param user 권한 확인
+     * @return 좋아요 취소 결과
+     */
+    ReviewResponseDto deleteReviewLike(Long reviewId, User user);
 }

--- a/src/main/java/com/sparta/lafesta/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/sparta/lafesta/review/service/ReviewServiceImpl.java
@@ -2,6 +2,8 @@ package com.sparta.lafesta.review.service;
 
 import com.sparta.lafesta.festival.entity.Festival;
 import com.sparta.lafesta.festival.service.FestivalServiceImpl;
+import com.sparta.lafesta.like.reviewLike.entity.ReviewLike;
+import com.sparta.lafesta.like.reviewLike.repository.ReviewLikeRepository;
 import com.sparta.lafesta.review.dto.ReviewRequestDto;
 import com.sparta.lafesta.review.dto.ReviewResponseDto;
 import com.sparta.lafesta.review.entity.Review;
@@ -19,6 +21,7 @@ import java.util.stream.Collectors;
 public class ReviewServiceImpl implements ReviewService {
     private final ReviewRepository reviewRepository;
     private final FestivalServiceImpl festivalService;
+    private final ReviewLikeRepository reviewLikeRepository;
 
     // 리뷰 생성
     @Override
@@ -68,10 +71,45 @@ public class ReviewServiceImpl implements ReviewService {
         reviewRepository.delete(review);
     }
 
+    // 리뷰 좋아요 추가
+    @Override
+    @Transactional
+    public ReviewResponseDto createReviewLike(Long reviewId, User user) {
+        Review review = findReview(reviewId);
+        // 좋아요를 이미 누른 경우 오류 반환
+        if (findReviewLike(user, review) != null) {
+            throw new IllegalArgumentException("좋아요를 이미 누르셨습니다.");
+        }
+        // 오류가 나지 않을 경우 해당 리뷰에 좋아요 추가
+        reviewLikeRepository.save(new ReviewLike(user, review));
+
+        return new ReviewResponseDto(review);
+    }
+
+    // 리뷰 좋아요 취소
+    @Override
+    @Transactional
+    public ReviewResponseDto deleteReviewLike(Long reviewId, User user) {
+        Review review = findReview(reviewId);
+        // 좋아요를 누르지 않은 경우 오류 반환
+        if (findReviewLike(user, review) == null) {
+            throw new IllegalArgumentException("좋아요를 누르시지 않았습니다.");
+        }
+        // 오류가 나지 않을 경우 해당 페스티벌에 좋아요 취소
+        reviewLikeRepository.delete(findReviewLike(user, review));
+
+        return new ReviewResponseDto(review);
+    }
+
     // 리뷰 id로 리뷰 찾기
     public Review findReview(Long reviewId) {
         return reviewRepository.findById(reviewId).orElseThrow(() ->
                 new IllegalArgumentException("선택한 리뷰는 존재하지 않습니다.")
         );
+    }
+
+    // 리뷰와 사용자로 좋아요 찾기
+    private ReviewLike findReviewLike(User user, Review review) {
+        return reviewLikeRepository.findByUserAndReview(user, review).orElse(null);
     }
 }

--- a/src/main/java/com/sparta/lafesta/user/entity/User.java
+++ b/src/main/java/com/sparta/lafesta/user/entity/User.java
@@ -5,7 +5,7 @@ import lombok.*;
 
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Getter
 @Table(name = "users")


### PR DESCRIPTION
## 관련 Issue

[#14](https://github.com/LaFesta7/LikeFesta/issues/14#issue-1858633010)

## 변경 사항

* 페스티벌 좋아요 추가 및 취소 기능 구현
* 리뷰 좋아요 추가 및 취소 기능 구현
* 댓글 좋아요 추가 및 취소 기능 구현

## Todo List  

* 관리자/작성자 좋아요 시 좋아요를 못 누르도록 할 것인지 논의 후 예외 처리를 추가적으로 해줘야 합니다.

## Check List


- [X] 포스트맨으로 체크해 보았나요?

### 포스트맨 테스트 결과

<details>

#### 페스티벌 좋아요 추가
<img width="573" alt="image" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/23be83a4-b36b-425a-9009-67a7ddbf55aa">
<img width="392" alt="image" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/bbf86df4-bc52-44ed-8991-d07408a0ff87">

#### 페스티벌 좋아요 취소
<img width="566" alt="image" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/63a3dc03-742e-43e1-962f-6950f3df4f2c">
<img width="397" alt="image" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/3e77cf19-2ef7-42da-96c4-654ee77a6a7b">

#### 리뷰 좋아요 추가
<img width="569" alt="image" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/ddacbc51-1e3c-4225-9309-43e6f5e12871">
<img width="520" alt="image" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/aac5e2c4-5d06-4273-a3de-ded2dee8416b">

#### 리뷰 좋아요 취소
<img width="571" alt="image" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/019ca088-ee19-469e-8965-dbb58993f06f">
<img width="481" alt="image" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/5ed6e0f2-a0af-492b-b23d-72883377fda1">

#### 댓글 좋아요 추가
<img width="568" alt="image" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/aea83cf5-dcd3-4883-85a5-4cdbcd184609">
<img width="398" alt="image" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/bf1a1e35-a088-4230-a0d1-8d6312443b3f">

#### 댓글 좋아요 취소
<img width="579" alt="image" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/44e7b360-1f82-47ab-9406-770d4af406e0">
<img width="408" alt="image" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/869ab6b4-c5f7-4b7f-bb52-af398b397f3a">

#### 예외처리 1: 좋아요 추가 시 좋아요를 이미 누른 경우
<img width="575" alt="image" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/bc54f4d6-26bc-42f2-85a4-07257ce33284">

#### 예외처리 2: 좋아요 취소 시 좋아요를 이미 누른 경우
<img width="571" alt="image" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/f0266222-95e9-4e4c-9e24-35d11b6b8647">

#### 예외처리 3: Pathvariable로 받은 값이 존재하지 않는 경우
<img width="571" alt="image" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/7601ba14-3204-4b1a-9627-9a5e87be7b8b">

</details>


## 트러블 슈팅 - 좋아요 수 반환에 대한 고민, 좋아요 취소 시 response에 좋아요 수가 줄어들지 않는 오류

<details>

### 1. 좋아요 수 반환에 대한 고민

1. Comment Entity -> DB 에 likeCnt열을 추가해서 좋아요 추가/취소가 발생할 때마다 'CommentLike 추가/삭제 + comment Entity'를 수정하는 방법
2. Comment Entity는 그대로 두고 -> 좋아요 추가/취소가 발생할 때마다 'CommentLike 추가/삭제' -> commentResponseDto에서 commentLike 갯수를 세는 방법

<br>

* 어떤 방법이 DB나 성능 최적화에 더 좋은 방법인지 혹은 현업에 더 적합한 방법일지 고민하게 됨

<br>

=> 이승은 튜터님께 여쭤봐서 해결

<br>

* 정규화(중복 데이터 최대한 저장하지 않도록 하는 게 목적) 관점에서 1번 방법은 중복된 데이터를 저장하는 방법이므로 옳지 않음.
* commentLike 갯수를 세는 게 성능에 무리가 갈까 싶어 여쭤봄 -> comment를 가져올 때 commentLike를 가져오게 되므로 현재의 프로젝트에서 count()가 크게 무리가 될 것으로 보이지 않음
* 현업에서는 성능 최적화를 진행하기 위하여 반정규화를 진행하기도 함
* 정규화 관점, 성능 최적화 등을 고려하여 우리의 프로젝트에 맞는 방법을 선택하여 진행하시면 된다는 답변을 받음

#### 결론) 
> commentLike를 어차피 comment를 불러올 때 가져온다면 -> 우리의 프로젝트가 count() 메소드로 성능에 크게 무리를 가져올 만큼의 규모는 아니라 생각되어 정규화 관점을 지키고자 2번 방법으로 진행

<br>
<br>

### 2. 좋아요 취소 시 response에 좋아요 수가 줄어들지 않는 오류
#### 발생한 예외
좋아요 취소 시 response에 좋아요 수가 줄어들지 않고 이전의 좋아요 수를 반환하는 오류가 발생함

* 예외가 발생한 코드

```
// 리뷰 좋아요 취소
@Override
@Transactional
public CommentResponseDto deleteCommentLike(Long commentId, User user) {
    Comment comment = findComment(commentId);
    // 좋아요를 누르지 않은 경우 오류 반환
    if (findCommentLike(user, comment) == null) {
        throw new IllegalArgumentException("좋아요를 누르시지 않았습니다.");
    }
    // 오류가 나지 않을 경우 해당 페스티벌에 좋아요 취소
    commentLikeRepository.delete(findCommentLike(user, comment));

    return new CommentResponseDto(comment);
}
```

* 원인 분석

> transaction commit이 메소드 완전히 종료 후 반영되므로 좋아요 수가 이전에 존재하던 수로 가져오게 됨
-> transaction을 중간에 커밋하는 방법으로 문제 해결

* 수정한 코드

```java
// 댓글 좋아요 취소
    @Override
    public CommentResponseDto deleteCommentLike(Long commentId, User user) {
        CommentResponseDto response = transactionTemplate.execute(status -> {
            Comment comment = findComment(commentId);
            // 좋아요를 누르지 않은 경우 오류 반환
            if (findCommentLike(user, comment) == null) {
                throw new IllegalArgumentException("좋아요를 누르시지 않았습니다.");
            }
            // 오류가 나지 않을 경우 해당 댓글에 좋아요 취소
            commentLikeRepository.delete(findCommentLike(user, comment));

            // 여기에서 커밋을 수행 (트랜잭션 내에서 커밋 또는 롤백을 수행할 수 있음)
            status.flush();

            // CommentResponseDto 생성 후 반환
            return new CommentResponseDto(comment);
        });

        // 위에서 커밋이 수행되었으므로 CommentResponseDto에서 새로운 likeCnt를 가져올 수 있음
        return response;
    }
```

> 해당 방법이 자주 사용하지 않는 방법인 거 같아 이승은 튜터님께 해당 방법이 문제가 없는지 여쭤봄 -> 사이드 이펙트가 있을지 고민하신 후 알려주시기로 하셨음!

</details>