### PR TITLE
[CI] CI 환경변수 등 코드 수정

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -54,6 +54,14 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
+      # 환경 변수 세팅
+      - name: properties 파일 생성
+        run: |
+          cd ./src/main/resources
+          touch ./application-test.properties
+          echo "${{secrets.APPLICATION_TEST_PROPERTIES}}" > ./application-test.properties
+        shell: bash
+
       # gradle 실행 허가
       - name: Run chmod to make gradlew executable
         run: chmod +x ./gradlew

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -58,8 +58,8 @@ jobs:
       - name: properties 파일 생성
         run: |
           cd ./src/main/resources
-          touch ./application-test.properties
-          echo "${{secrets.APPLICATION_TEST_PROPERTIES}}" > ./application-test.properties
+          touch ./application-s3.properties
+          echo "${{secrets.APPLICATION_S3_PROPERTIES}}" > ./application-s3.properties
         shell: bash
 
       # gradle 실행 허가

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      DB_URL: jdbc:mysql://localhost:3306/test_db
-      DB_USER: root
-      DB_PASSWORD: root
+      DB_URL: ${{ secrets.DB_URL }}
+      DB_USER: ${{ secrets.DB_USER }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
       JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
       KAKAO_REST_API: ${{ secrets.KAKAO_REST_API }}
       MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
@@ -37,8 +37,8 @@ jobs:
       mysql:
         image: mysql:latest
         env:
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: test_db
+          MYSQL_ROOT_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          MYSQL_DATABASE: ${{ secrets.DB_DATABASE }}
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping"
@@ -66,11 +66,7 @@ jobs:
       - name: Run chmod to make gradlew executable
         run: chmod +x ./gradlew
 
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
-        with:
-          arguments: build
-
+      # Build with Gradle 대체
       - name: 어플리케이션 실행 테스트(테스트 코드X)
         run: ./gradlew clean build --exclude-task test
 


### PR DESCRIPTION
1. [fix] 기존 `application-test.properties` 로 추가할 경우 application.properties에서 주입받을 `application-s3.properties`가 생성되지 않아 CI가 돌아가지 않음 -> `application-s3.properties`를 생성하도록 코드 수정

2. [refactor] MYSQL 서비스가 테스트 환경에서만 외부에서 임시로 사용하는 서비스긴 하지만 정보가 숨겨져 있는것이 더 안전하다고 판단되어 해당 부분 환경변수로 수정

3. [refactor] 이전에 추가한 build with Gradle 단이 아래 있던 어플리케이션 실행 테스트 단으로 대체가 가능하다는 것을 알게되어 필요하지 않은 build with Gradle은 삭제 진행함