### PR TITLE
[Feature] 웹알림 CRUD 구현

### DIFF
--- a/src/main/java/com/sparta/lafesta/festival/event/FestivalCreatedEvent.java
+++ b/src/main/java/com/sparta/lafesta/festival/event/FestivalCreatedEvent.java
@@ -1,0 +1,20 @@
+package com.sparta.lafesta.festival.event;
+
+import com.sparta.lafesta.festival.entity.Festival;
+import com.sparta.lafesta.user.entity.User;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+import java.util.List;
+
+@Getter
+public class FestivalCreatedEvent extends ApplicationEvent {
+    private final Festival festival;
+    private final List<User> followers;
+
+    public FestivalCreatedEvent(Object source, Festival festival, List<User> followers) {
+        super(source);
+        this.festival = festival;
+        this.followers = followers;
+    }
+}

--- a/src/main/java/com/sparta/lafesta/festival/event/FestivalCreatedEventListener.java
+++ b/src/main/java/com/sparta/lafesta/festival/event/FestivalCreatedEventListener.java
@@ -23,12 +23,13 @@ public class FestivalCreatedEventListener implements ApplicationListener<Festiva
     @TransactionalEventListener
     public void onApplicationEvent(FestivalCreatedEvent event) {
         Festival festival = event.getFestival();
-        String title = festival.getTitle();
+        String title = festival.getTitle()  + " 게시 안내";
         String editor = festival.getUser().getNickname();
+        String detail = "팔로우 하신 " + editor + "님께서 " + title + "을/를 게시했습니다.";
         LocalDateTime createdAt = festival.getCreatedAt();
         List<User> followers = event.getFollowers();
         for (User follower : followers) {
-            Notification notification = new Notification(title, editor, createdAt, follower);
+            Notification notification = new Notification(title, detail, createdAt, follower);
             notificationService.saveNotification(notification);
         }
         log.info("페스티벌 작성 이벤트 발생");

--- a/src/main/java/com/sparta/lafesta/festival/event/FestivalCreatedEventListener.java
+++ b/src/main/java/com/sparta/lafesta/festival/event/FestivalCreatedEventListener.java
@@ -1,0 +1,36 @@
+package com.sparta.lafesta.festival.event;
+
+import com.sparta.lafesta.festival.entity.Festival;
+import com.sparta.lafesta.notification.entity.Notification;
+import com.sparta.lafesta.notification.service.NotificationService;
+import com.sparta.lafesta.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j(topic = "Event Listener")
+@Component
+@RequiredArgsConstructor
+public class FestivalCreatedEventListener implements ApplicationListener<FestivalCreatedEvent> {
+    private final NotificationService notificationService;
+
+    @Override
+    @TransactionalEventListener
+    public void onApplicationEvent(FestivalCreatedEvent event) {
+        Festival festival = event.getFestival();
+        String title = festival.getTitle();
+        String editor = festival.getUser().getNickname();
+        LocalDateTime createdAt = festival.getCreatedAt();
+        List<User> followers = event.getFollowers();
+        for (User follower : followers) {
+            Notification notification = new Notification(title, editor, createdAt, follower);
+            notificationService.saveNotification(notification);
+        }
+        log.info("페스티벌 작성 이벤트 발생");
+    }
+}

--- a/src/main/java/com/sparta/lafesta/festival/event/FestivalCreatedEventPublisher.java
+++ b/src/main/java/com/sparta/lafesta/festival/event/FestivalCreatedEventPublisher.java
@@ -1,0 +1,34 @@
+package com.sparta.lafesta.festival.event;
+
+import com.sparta.lafesta.festival.entity.Festival;
+import com.sparta.lafesta.follow.service.FollowService;
+import com.sparta.lafesta.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j(topic = "Event Publisher")
+@Component
+@EnableAsync
+@RequiredArgsConstructor
+public class FestivalCreatedEventPublisher {
+    public final ApplicationEventPublisher eventPublisher;
+    private final FollowService followService;
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void publishFestivalCreatedEvent(Festival festival) {
+        User editor = festival.getUser();
+        List<User> followers = followService.findFollowers(editor);
+        FestivalCreatedEvent event = new FestivalCreatedEvent(this, festival, followers);
+        eventPublisher.publishEvent(event);
+        log.info("페스티벌 작성 이벤트 생성");
+    }
+}

--- a/src/main/java/com/sparta/lafesta/festival/service/FestivalServiceImpl.java
+++ b/src/main/java/com/sparta/lafesta/festival/service/FestivalServiceImpl.java
@@ -9,6 +9,7 @@ import com.sparta.lafesta.common.s3.repository.FestivalFileRepository;
 import com.sparta.lafesta.festival.dto.FestivalRequestDto;
 import com.sparta.lafesta.festival.dto.FestivalResponseDto;
 import com.sparta.lafesta.festival.entity.Festival;
+import com.sparta.lafesta.festival.event.FestivalCreatedEventPublisher;
 import com.sparta.lafesta.festival.repository.FestivalRepository;
 import com.sparta.lafesta.like.festivalLike.entity.FestivalLike;
 import com.sparta.lafesta.like.festivalLike.repository.FestivalLikeRepository;
@@ -46,6 +47,9 @@ public class FestivalServiceImpl implements FestivalService {
     //Like
     private final FestivalLikeRepository festivalLikeRepository;
 
+    // 알림
+    private final FestivalCreatedEventPublisher eventPublisher;
+
     @Autowired
     private TransactionTemplate transactionTemplate;
 
@@ -69,6 +73,9 @@ public class FestivalServiceImpl implements FestivalService {
         if (files != null) {
             uploadFiles(files, festival);
         }
+
+        // 이벤트 발생 -> 알림 생성
+        eventPublisher.publishFestivalCreatedEvent(festival);
 
         return new FestivalResponseDto(festival);
     }

--- a/src/main/java/com/sparta/lafesta/follow/service/FollowService.java
+++ b/src/main/java/com/sparta/lafesta/follow/service/FollowService.java
@@ -196,4 +196,15 @@ public class FollowService {
 
         return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), followedFestival.getTitle() + "을(를) 언팔로우 했습니다."));
     }
+
+    // 팔로우 유저 찾기
+    public List<User> findFollowers(User followedUser) {
+        List<UserFollow> followUsers = userFollowRepository.findAllByFollowedUser(followedUser);
+        List<User> followers = new ArrayList<>();
+        for (UserFollow follower : followUsers) {
+            User followerUser = userRepository.findByFollowers(follower).orElse(null);
+            followers.add(followerUser);
+        }
+        return followers;
+    }
 }

--- a/src/main/java/com/sparta/lafesta/notification/controller/NotificationController.java
+++ b/src/main/java/com/sparta/lafesta/notification/controller/NotificationController.java
@@ -1,0 +1,34 @@
+package com.sparta.lafesta.notification.controller;
+
+import com.sparta.lafesta.common.security.UserDetailsImpl;
+import com.sparta.lafesta.notification.dto.NotificationResponseDto;
+import com.sparta.lafesta.notification.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@Tag(name = "알림 관련 API", description = "알림 관련 API 입니다.")
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    @GetMapping("/users/{userId}/notifications")
+    @Operation(summary = "알림 전체 조회", description = "로그인 한 유저의 정보를 가져와, 해당 유저에게 온 알림을 모두 조회합니다.")
+    public List<NotificationResponseDto> getNotifications(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return notificationService.getNotifications(userDetails.getUser());
+    }
+
+    @PatchMapping("/users/{userId}/notifications/{notificationId}")
+    @Operation(summary = "알림 읽음 처리", description = "@PathVariable을 통해 notificationId를 받아와, 해당 알림을 읽음 처리합니다.")
+    public ResponseEntity<NotificationResponseDto> readNotification(
+            @PathVariable Long notificationId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ResponseEntity.ok().body(notificationService.readNotification(notificationId, userDetails.getUser()));
+    }
+}

--- a/src/main/java/com/sparta/lafesta/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/sparta/lafesta/notification/dto/NotificationResponseDto.java
@@ -12,13 +12,13 @@ public class NotificationResponseDto {
     private String title;
     private String detail;
     private String timeSinceCreated;
-    private Boolean read;
+    private Boolean rd;
 
     public NotificationResponseDto(Notification notification) {
         this.id = notification.getId();
         this.title = notification.getTitle();
         this.detail = notification.getDetail();
         this.timeSinceCreated = Duration.between(notification.getCreatedAt(), LocalDateTime.now()).toString();
-        this.read = notification.getRead();
+        this.rd = notification.getRd();
     }
 }

--- a/src/main/java/com/sparta/lafesta/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/sparta/lafesta/notification/dto/NotificationResponseDto.java
@@ -9,7 +9,6 @@ import java.time.LocalDateTime;
 @Getter
 public class NotificationResponseDto {
     private Long id;
-    private String editor;
     private String title;
     private String detail;
     private String timeSinceCreated;
@@ -17,9 +16,8 @@ public class NotificationResponseDto {
 
     public NotificationResponseDto(Notification notification) {
         this.id = notification.getId();
-        this.title = notification.getTitle() + " 게시 안내";
-        this.editor = notification.getEditor();
-        this.detail = "팔로우 하신 " + getEditor() + "님께서 " + getTitle() + "을/를 게시했습니다.";
+        this.title = notification.getTitle();
+        this.detail = notification.getDetail();
         this.timeSinceCreated = Duration.between(notification.getCreatedAt(), LocalDateTime.now()).toString();
         this.read = notification.getRead();
     }

--- a/src/main/java/com/sparta/lafesta/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/sparta/lafesta/notification/dto/NotificationResponseDto.java
@@ -1,0 +1,26 @@
+package com.sparta.lafesta.notification.dto;
+
+import com.sparta.lafesta.notification.entity.Notification;
+import lombok.Getter;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Getter
+public class NotificationResponseDto {
+    private Long id;
+    private String editor;
+    private String title;
+    private String detail;
+    private String timeSinceCreated;
+    private Boolean read;
+
+    public NotificationResponseDto(Notification notification) {
+        this.id = notification.getId();
+        this.title = notification.getTitle() + " 게시 안내";
+        this.editor = notification.getEditor();
+        this.detail = "팔로우 하신 " + getEditor() + "님께서 " + getTitle() + "을/를 게시했습니다.";
+        this.timeSinceCreated = Duration.between(notification.getCreatedAt(), LocalDateTime.now()).toString();
+        this.read = notification.getRead();
+    }
+}

--- a/src/main/java/com/sparta/lafesta/notification/dto/ReminderDto.java
+++ b/src/main/java/com/sparta/lafesta/notification/dto/ReminderDto.java
@@ -39,7 +39,7 @@ public class ReminderDto {
         }
         this.festivalFollowUsers = festival.getFestivalFollowers().stream()
                 .map(FestivalFollow::getFollowingFestivalUser)
-                .collect(Collectors.toList());
+                .toList();
         this.festivalFollowUsersEmail = festivalFollowUsers.stream().map(User::getEmail).toList();
     }
 

--- a/src/main/java/com/sparta/lafesta/notification/dto/ReminderDto.java
+++ b/src/main/java/com/sparta/lafesta/notification/dto/ReminderDto.java
@@ -22,6 +22,7 @@ public class ReminderDto {
     private String festivalLocate;
     private String reservationOpenDate;
     private String reservationPlace;
+    private List<User> festivalFollowUsers;
     private List<String> festivalFollowUsersEmail;
 
     public ReminderDto(Festival festival, FestivalReminderType type) {
@@ -37,10 +38,10 @@ public class ReminderDto {
             this.reservationOpenDate = formFestivalDate(festival, FestivalReminderType.RESERVATION_OPEN);
             this.reservationPlace = festival.getReservationPlace();
         }
-        this.festivalFollowUsersEmail = festival.getFestivalFollowers().stream()
+        this.festivalFollowUsers = festival.getFestivalFollowers().stream()
                 .map(FestivalFollow::getFollowingFestivalUser)
-                .map(User::getEmail)
                 .collect(Collectors.toList());
+        this.festivalFollowUsersEmail = festivalFollowUsers.stream().map(User::getEmail).toList();
     }
 
     // 타입별로 메일 제목 가져오기
@@ -72,9 +73,9 @@ public class ReminderDto {
     // 페스티벌 오픈 - 메일 제목 만들기
     private String makeFestivalOpenMailTitle(Festival festival) {
         StringBuilder sb = new StringBuilder();
-        sb.append("' ");
+        sb.append("'");
         sb.append(festival.getTitle());
-        sb.append(" '");
+        sb.append("'");
         sb.append(" 개막 ");
         if (getDaysDifference(festival, FestivalReminderType.FESTIVAL_OPEN) > 0) {
             sb.append(getDaysDifference(festival, FestivalReminderType.FESTIVAL_OPEN));
@@ -88,7 +89,10 @@ public class ReminderDto {
     // 페스티벌 오픈 - 메일 내용 만들기
     private String makeFestivalOpenMailContent(Festival festival) {
         StringBuilder sb = new StringBuilder();
-        sb.append("팔로우 하신 페스티벌");
+        sb.append("팔로우 하신 ");
+        sb.append("'");
+        sb.append(festival.getTitle());
+        sb.append("'");
         sb.append(" 개막 ");
         if (getDaysDifference(festival, FestivalReminderType.FESTIVAL_OPEN) > 0) {
             sb.append(getDaysDifference(festival, FestivalReminderType.FESTIVAL_OPEN));
@@ -103,9 +107,9 @@ public class ReminderDto {
     // 예매 오픈 - 메일 제목 만들기
     private String makeReservationOpenMailTitle(Festival festival) {
         StringBuilder sb = new StringBuilder();
-        sb.append("' ");
+        sb.append("'");
         sb.append(festival.getTitle());
-        sb.append(" '");
+        sb.append("'");
         sb.append(" 예매 오픈 ");
         if (getDaysDifference(festival, FestivalReminderType.RESERVATION_OPEN) > 0) {
             sb.append(getDaysDifference(festival, FestivalReminderType.RESERVATION_OPEN));
@@ -119,7 +123,10 @@ public class ReminderDto {
     // 예매 오픈 - 메일 내용 만들기
     private String makeReservationOpenMailContent(Festival festival) {
         StringBuilder sb = new StringBuilder();
-        sb.append("팔로우 하신 페스티벌");
+        sb.append("팔로우 하신 ");
+        sb.append("'");
+        sb.append(festival.getTitle());
+        sb.append("'");
         sb.append(" 예매 오픈 ");
         if (getDaysDifference(festival, FestivalReminderType.RESERVATION_OPEN) > 0) {
             sb.append(getDaysDifference(festival, FestivalReminderType.RESERVATION_OPEN));
@@ -134,9 +141,9 @@ public class ReminderDto {
     // 리뷰 독려 - 메일 제목 만들기
     private String makeReviewEncouragementMailTitle(Festival festival) {
         StringBuilder sb = new StringBuilder();
-        sb.append("' ");
+        sb.append("'");
         sb.append(festival.getTitle());
-        sb.append(" '");
+        sb.append("'");
         sb.append(" 리뷰 작성 알림");
 
         return sb.toString();
@@ -145,7 +152,11 @@ public class ReminderDto {
     // 리뷰 독려 - 메일 내용 만들기
     private String makeReviewEncouragementMailContent(Festival festival) {
         StringBuilder sb = new StringBuilder();
-        sb.append("팔로우 하신 페스티벌에 다녀오셨나요? 리뷰를 작성해보세요!");
+        sb.append("팔로우 하신 ");
+        sb.append("'");
+        sb.append(festival.getTitle());
+        sb.append("'");
+        sb.append("에 다녀오셨나요? 리뷰를 작성해보세요!");
 
         return sb.toString();
     }

--- a/src/main/java/com/sparta/lafesta/notification/entity/Notification.java
+++ b/src/main/java/com/sparta/lafesta/notification/entity/Notification.java
@@ -26,8 +26,8 @@ public class Notification {
     @Column(name = "createdAt", nullable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "`read`", nullable = false)
-    private Boolean read;
+    @Column(name = "rd", nullable = false)
+    private Boolean rd;
 
     // 알림 받을 follower
     @ManyToOne(fetch = FetchType.LAZY)
@@ -42,12 +42,12 @@ public class Notification {
         this.title = title;
         this.detail = detail;
         this.createdAt = createdAt;
-        this.read = false;
+        this.rd = false;
         this.expirationTime = LocalDateTime.now().plusDays(7);
     }
 
     public void readNotification() {
-        this.read = true;
+        this.rd = true;
         this.expirationTime = LocalDateTime.now().plusDays(3);
     }
 }

--- a/src/main/java/com/sparta/lafesta/notification/entity/Notification.java
+++ b/src/main/java/com/sparta/lafesta/notification/entity/Notification.java
@@ -20,8 +20,8 @@ public class Notification {
     @Column(name = "title", nullable = false)
     private String title;
 
-    @Column(name = "editor", nullable = false)
-    private String editor;
+    @Column(name = "detail", nullable = false)
+    private String detail;
 
     @Column(name = "createdAt", nullable = false)
     private LocalDateTime createdAt;
@@ -37,10 +37,10 @@ public class Notification {
     @Column(nullable = false)
     private LocalDateTime expirationTime;
 
-    public Notification(String title, String editor, LocalDateTime createdAt, User follower) {
+    public Notification(String title, String detail, LocalDateTime createdAt, User follower) {
         this.follower = follower;
         this.title = title;
-        this.editor = editor;
+        this.detail = detail;
         this.createdAt = createdAt;
         this.read = false;
         this.expirationTime = LocalDateTime.now().plusDays(7);

--- a/src/main/java/com/sparta/lafesta/notification/entity/Notification.java
+++ b/src/main/java/com/sparta/lafesta/notification/entity/Notification.java
@@ -1,0 +1,53 @@
+package com.sparta.lafesta.notification.entity;
+
+import com.sparta.lafesta.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notifications")
+public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "editor", nullable = false)
+    private String editor;
+
+    @Column(name = "createdAt", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "`read`", nullable = false)
+    private Boolean read;
+
+    // 알림 받을 follower
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User follower;
+
+    @Column(nullable = false)
+    private LocalDateTime expirationTime;
+
+    public Notification(String title, String editor, LocalDateTime createdAt, User follower) {
+        this.follower = follower;
+        this.title = title;
+        this.editor = editor;
+        this.createdAt = createdAt;
+        this.read = false;
+        this.expirationTime = LocalDateTime.now().plusDays(7);
+    }
+
+    public void readNotification() {
+        this.read = true;
+        this.expirationTime = LocalDateTime.now().plusDays(3);
+    }
+}

--- a/src/main/java/com/sparta/lafesta/notification/event/ReminderSendEmailEvent.java
+++ b/src/main/java/com/sparta/lafesta/notification/event/ReminderSendEmailEvent.java
@@ -1,0 +1,20 @@
+package com.sparta.lafesta.notification.event;
+
+import com.sparta.lafesta.notification.dto.ReminderDto;
+import com.sparta.lafesta.user.entity.User;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+import java.util.List;
+
+@Getter
+public class ReminderSendEmailEvent extends ApplicationEvent {
+    private final ReminderDto reminder;
+    private final List<User> followers;
+
+    public ReminderSendEmailEvent(Object source, ReminderDto reminder, List<User> followers) {
+        super(source);
+        this.reminder = reminder;
+        this.followers = followers;
+    }
+}

--- a/src/main/java/com/sparta/lafesta/notification/event/ReminderSendEmailEventPublisher.java
+++ b/src/main/java/com/sparta/lafesta/notification/event/ReminderSendEmailEventPublisher.java
@@ -1,0 +1,33 @@
+package com.sparta.lafesta.notification.event;
+
+import com.sparta.lafesta.follow.service.FollowService;
+import com.sparta.lafesta.notification.dto.ReminderDto;
+import com.sparta.lafesta.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j(topic = "Event Publisher")
+@Component
+@EnableAsync
+@RequiredArgsConstructor
+public class ReminderSendEmailEventPublisher {
+    public final ApplicationEventPublisher eventPublisher;
+    private final FollowService followService;
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void publishReminderSendEmailEvent(ReminderDto reminder) {
+        List<User> followers = reminder.getFestivalFollowUsers();
+        ReminderSendEmailEvent event = new ReminderSendEmailEvent(this, reminder, followers);
+        eventPublisher.publishEvent(event);
+        log.info("리마인더 이벤트 생성");
+    }
+}

--- a/src/main/java/com/sparta/lafesta/notification/event/ReminderSendEventListener.java
+++ b/src/main/java/com/sparta/lafesta/notification/event/ReminderSendEventListener.java
@@ -1,8 +1,8 @@
-package com.sparta.lafesta.review.event;
+package com.sparta.lafesta.notification.event;
 
+import com.sparta.lafesta.notification.dto.ReminderDto;
 import com.sparta.lafesta.notification.entity.Notification;
 import com.sparta.lafesta.notification.service.NotificationService;
-import com.sparta.lafesta.review.entity.Review;
 import com.sparta.lafesta.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,22 +16,21 @@ import java.util.List;
 @Slf4j(topic = "Event Listener")
 @Component
 @RequiredArgsConstructor
-public class ReviewCreatedEventListener implements ApplicationListener<ReviewCreatedEvent> {
+public class ReminderSendEventListener implements ApplicationListener<ReminderSendEmailEvent> {
     private final NotificationService notificationService;
 
     @Override
     @TransactionalEventListener
-    public void onApplicationEvent(ReviewCreatedEvent event) {
-        Review review = event.getReview();
-        String title = "'" + review.getTitle() + "'" + " 게시 안내";
-        String editor = review.getUser().getNickname();
-        String detail = "팔로우 하신 " + "'" + editor + "'" + "님께서 " + "'" + title + "'"  + "을/를 게시했습니다.";
-        LocalDateTime createdAt = review.getCreatedAt();
+    public void onApplicationEvent(ReminderSendEmailEvent event) {
+        ReminderDto reminder = event.getReminder();
+        String title = reminder.getMailTitle();
+        String detail = reminder.getMailContent();
+        LocalDateTime createdAt = LocalDateTime.now();
         List<User> followers = event.getFollowers();
         for (User follower : followers) {
             Notification notification = new Notification(title, detail, createdAt, follower);
             notificationService.saveNotification(notification);
         }
-        log.info("리뷰 작성 이벤트 발생");
+        log.info("리마인더 이벤트 발생");
     }
 }

--- a/src/main/java/com/sparta/lafesta/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/sparta/lafesta/notification/repository/NotificationRepository.java
@@ -1,0 +1,16 @@
+package com.sparta.lafesta.notification.repository;
+
+import com.sparta.lafesta.notification.entity.Notification;
+import com.sparta.lafesta.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long>  {
+
+    List<Notification> findAllByFollower(User user);
+
+    void deleteByExpirationTimeBefore(LocalDateTime now);
+
+}

--- a/src/main/java/com/sparta/lafesta/notification/service/NotificationService.java
+++ b/src/main/java/com/sparta/lafesta/notification/service/NotificationService.java
@@ -2,9 +2,8 @@ package com.sparta.lafesta.notification.service;
 
 import com.sparta.lafesta.common.exception.UnauthorizedException;
 import com.sparta.lafesta.email.service.MailService;
-import com.sparta.lafesta.festival.service.FestivalServiceImpl;
-import com.sparta.lafesta.notification.dto.NotificationResponseDto;
 import com.sparta.lafesta.festival.service.FestivalService;
+import com.sparta.lafesta.notification.dto.NotificationResponseDto;
 import com.sparta.lafesta.notification.dto.ReminderDto;
 import com.sparta.lafesta.notification.entity.Notification;
 import com.sparta.lafesta.notification.event.ReminderSendEmailEventPublisher;

--- a/src/main/java/com/sparta/lafesta/notification/service/NotificationService.java
+++ b/src/main/java/com/sparta/lafesta/notification/service/NotificationService.java
@@ -90,7 +90,7 @@ public class NotificationService {
         if (!notification.getFollower().getId().equals(user.getId())) {
             throw new UnauthorizedException("해당 알림을 읽을 권한이 없습니다.");
         }
-        if (notification.getRead()) {
+        if (notification.getRd()) {
             throw new IllegalArgumentException("해당 알림은 이미 읽으셨습니다.");
         }
         notification.readNotification();

--- a/src/main/java/com/sparta/lafesta/notification/service/NotificationService.java
+++ b/src/main/java/com/sparta/lafesta/notification/service/NotificationService.java
@@ -1,18 +1,26 @@
 package com.sparta.lafesta.notification.service;
 
+import com.sparta.lafesta.common.exception.UnauthorizedException;
 import com.sparta.lafesta.email.service.MailService;
 import com.sparta.lafesta.festival.service.FestivalServiceImpl;
+import com.sparta.lafesta.notification.dto.NotificationResponseDto;
 import com.sparta.lafesta.notification.dto.ReminderDto;
+import com.sparta.lafesta.notification.entity.Notification;
+import com.sparta.lafesta.notification.repository.NotificationRepository;
+import com.sparta.lafesta.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
 
+    private final NotificationRepository notificationRepository;
     private final MailService mailService;
     private final FestivalServiceImpl festivalService;
 
@@ -53,5 +61,46 @@ public class NotificationService {
                 }
             }
         }
+    }
+
+    // 알림 생성
+    @Transactional
+    public void saveNotification(Notification notification) {
+        notificationRepository.save(notification);
+    }
+
+    // 알림 전체 조회
+    @Transactional(readOnly = true)
+    public List<NotificationResponseDto> getNotifications(User user) {
+        return notificationRepository.findAllByFollower(user)
+                .stream().map(NotificationResponseDto::new).toList();
+    }
+
+    // 알림 읽음 처리
+    @Transactional
+    public NotificationResponseDto readNotification(Long notificationId, User user) {
+        Notification notification = findNotification(notificationId);
+        if (!notification.getFollower().getId().equals(user.getId())) {
+            throw new UnauthorizedException("해당 알림을 읽을 권한이 없습니다.");
+        }
+        if (notification.getRead()) {
+            throw new IllegalArgumentException("해당 알림은 이미 읽으셨습니다.");
+        }
+        notification.readNotification();
+        return new NotificationResponseDto(notification);
+    }
+
+    // 알림 DB 30분마다 삭제하기
+    @Transactional
+    @Scheduled(fixedRate = 1800000) // 30분마다 실행
+    public void cleanupExpiredNotifications() {
+        notificationRepository.deleteByExpirationTimeBefore(LocalDateTime.now());
+    }
+
+    // id로 알림 찾기
+    private Notification findNotification (Long notificationId) {
+        return notificationRepository.findById(notificationId).orElseThrow(() ->
+                new IllegalArgumentException("선택한 알림은 존재하지 않습니다.")
+        );
     }
 }

--- a/src/main/java/com/sparta/lafesta/review/event/ReviewCreatedEvent.java
+++ b/src/main/java/com/sparta/lafesta/review/event/ReviewCreatedEvent.java
@@ -1,0 +1,20 @@
+package com.sparta.lafesta.review.event;
+
+import com.sparta.lafesta.review.entity.Review;
+import com.sparta.lafesta.user.entity.User;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+import java.util.List;
+
+@Getter
+public class ReviewCreatedEvent extends ApplicationEvent {
+    private final Review review;
+    private final List<User> followers;
+
+    public ReviewCreatedEvent(Object source, Review review, List<User> followers) {
+        super(source);
+        this.review = review;
+        this.followers = followers;
+    }
+}

--- a/src/main/java/com/sparta/lafesta/review/event/ReviewCreatedEventListener.java
+++ b/src/main/java/com/sparta/lafesta/review/event/ReviewCreatedEventListener.java
@@ -1,0 +1,36 @@
+package com.sparta.lafesta.review.event;
+
+import com.sparta.lafesta.notification.entity.Notification;
+import com.sparta.lafesta.notification.service.NotificationService;
+import com.sparta.lafesta.review.entity.Review;
+import com.sparta.lafesta.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j(topic = "Event Listener")
+@Component
+@RequiredArgsConstructor
+public class ReviewCreatedEventListener implements ApplicationListener<ReviewCreatedEvent> {
+    private final NotificationService notificationService;
+
+    @Override
+    @TransactionalEventListener
+    public void onApplicationEvent(ReviewCreatedEvent event) {
+        Review review = event.getReview();
+        String title = review.getTitle();
+        String editor = review.getUser().getNickname();
+        LocalDateTime createdAt = review.getCreatedAt();
+        List<User> followers = event.getFollowers();
+        for (User follower : followers) {
+            Notification notification = new Notification(title, editor, createdAt, follower);
+            notificationService.saveNotification(notification);
+        }
+        log.info("리뷰 작성 이벤트 발생");
+    }
+}

--- a/src/main/java/com/sparta/lafesta/review/event/ReviewCreatedEventPublisher.java
+++ b/src/main/java/com/sparta/lafesta/review/event/ReviewCreatedEventPublisher.java
@@ -1,0 +1,34 @@
+package com.sparta.lafesta.review.event;
+
+import com.sparta.lafesta.follow.service.FollowService;
+import com.sparta.lafesta.review.entity.Review;
+import com.sparta.lafesta.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j(topic = "Event Publisher")
+@Component
+@EnableAsync
+@RequiredArgsConstructor
+public class ReviewCreatedEventPublisher {
+    public final ApplicationEventPublisher eventPublisher;
+    private final FollowService followService;
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void publishReviewCreatedEvent(Review review) {
+        User editor = review.getUser();
+        List<User> followers = followService.findFollowers(editor);
+        ReviewCreatedEvent event = new ReviewCreatedEvent(this, review, followers);
+        eventPublisher.publishEvent(event);
+        log.info("리뷰 작성 이벤트 생성");
+    }
+}

--- a/src/main/java/com/sparta/lafesta/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/sparta/lafesta/review/service/ReviewServiceImpl.java
@@ -12,6 +12,7 @@ import com.sparta.lafesta.like.reviewLike.repository.ReviewLikeRepository;
 import com.sparta.lafesta.review.dto.ReviewRequestDto;
 import com.sparta.lafesta.review.dto.ReviewResponseDto;
 import com.sparta.lafesta.review.entity.Review;
+import com.sparta.lafesta.review.event.ReviewCreatedEventPublisher;
 import com.sparta.lafesta.review.repostiroy.ReviewRepository;
 import com.sparta.lafesta.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,9 @@ public class ReviewServiceImpl implements ReviewService {
     //Like
     private final ReviewLikeRepository reviewLikeRepository;
 
+    // 알림
+    private final ReviewCreatedEventPublisher eventPublisher;
+
     @Autowired
     private TransactionTemplate transactionTemplate;
 
@@ -63,6 +67,9 @@ public class ReviewServiceImpl implements ReviewService {
         if (files != null) {
             uploadFiles(files, review);
         }
+
+        // 이벤트 발생 -> 알림 생성
+        eventPublisher.publishReviewCreatedEvent(review);
 
         return new ReviewResponseDto(review);
     }


### PR DESCRIPTION
## 관련 Issue

#28 

## 변경 사항

#### 이벤트가 발생하면 바로 알림이 생성되는 알림 상황

1. 팔로우한 주최자가 페스티벌을 작성한 경우
2. 팔로우한 유저가 리뷰를 작성한 경우

#### 하루에 한번만 알림이 생성되는 알림 상황

 1. 팔로우한 페스티벌의 예매일 오픈 리마인드가 발송된 경우
 2. 팔로우한 페스티벌의 오픈 리마인드가 발송된 경우
 3. 팔로우한 페스티벌의 리뷰 리마인드가 발송된 경우

#### 웹 알림 기능 CRUD 구현

1. 팔로우한 유저가 글을 작성할 경우 / 리마인드 상황 시 이벤트 발생 -> 알림 생성
2. 유저에게 온 알림을 모두 조회할 수 있음
3. 알림을 읽음 처리할 수 있음
4. 알림 DB는 읽지 않을 경우, 알림 생성으로부터 7일, 읽을 경우, 알림을 읽은 시점으로부터 3일의 만료기간을 가지고 30분마다 만료된 알림을 삭제함

## Todo List

* 추후 웹소켓 등의 성능 개선 리팩토링 필요

## Check List

- [x] 포스트맨으로 체크해 보았나요?

* 이벤트 상황 발생 : 유저/페스티벌 팔로우가 맺어져 있고 각 팔로우에 맞는 알림 상황 발생

* 알림 전체 조회
<img width="556" alt="image" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/5609ef6f-a3ec-4eec-b304-4aa0f358260d">

* 알림 읽음 처리 (read: false -> true 변경)
<img width="428" alt="image" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/4623d4f7-93d7-4d15-a095-0d2452be5ac5">

* 만료 시간 및 실행 시간을 임의로 설정 후 주기적으로 삭제되는 것 확인 완료

## 트러블 슈팅
#### 이벤트 리스너에서 팔로워를 불러오지 못하는 문제

* 발생한 예외

```java
// 런타임 Exception
org.hibernate.LazyInitializationException: failed to lazily initialize a collection of role: com.sparta.lafesta.user.entity.User.followers: could not initialize proxy - no Session
```

* 예외가 발생한 코드

```java
// FestivalCreatedEvent
    public FestivalCreatedEvent(Object source, Festival festival) {
        super(source);
        this.festival = festival;
    }
}

// FestivalCreatedEventPublisher
    @Async
    @Transactional(propagation = Propagation.REQUIRES_NEW)
    public void publishFestivalCreatedEvent(Festival festival) {
        log.info("이벤트 생성");
        FestivalCreatedEvent event = new FestivalCreatedEvent(this, festival);
        eventPublisher.publishEvent(event);
    }

// FestivalCreatedEventListener
    @Override
    @TransactionalEventListener
    public void onApplicationEvent(FestivalCreatedEvent event) {
        Festival festival = event.getFestival();
        User editor = festival.getUser();
        List<UserFollow> userFollows = editor.getFollowers();
        (생략)
```

* 원인 분석

> Hibernate의 Lazy Loading 기능을 사용할 때 발생하는 문제. 이 오류는 엔티티의 연관 관계를 지연로딩(Lazy Loading)으로 설정했을 때, 실제 데이터를 조회하지 않은 상태에서 연관된 컬렉션을 접근하려고 할 때 발생. -> festival에서 user를 갖고와 user에서 follower들을 가져오려고 하니 발생한 문제였음 -> 레포지토리에서 직접 가져오니 문제 해결

* 수정한 코드

```java
// FestivalCreatedEvent
    public FestivalCreatedEvent(Object source, Festival festival, List<User> followers) {
        super(source);
        this.festival = festival;
        this.followers = followers;
    }
}

// FestivalCreatedEventPublisher
    @Async
    @Transactional(propagation = Propagation.REQUIRES_NEW)
    public void publishFestivalCreatedEvent(Festival festival) {
        User editor = festival.getUser();
        List<User> followers = followService.findFollowers(editor);
        FestivalCreatedEvent event = new FestivalCreatedEvent(this, festival, followers);
        eventPublisher.publishEvent(event);
        log.info("페스티벌 작성 이벤트 생성");
    }

// FollowService 메소드 추가
    public List<User> findFollowers(User followedUser) {
        List<UserFollow> followUsers = userFollowRepository.findAllByFollowedUser(followedUser);
        List<User> followers = new ArrayList<>();
        for (UserFollow follower : followUsers) {
            User followerUser = userRepository.findByFollowers(follower).orElse(null);
            followers.add(followerUser);
        }
        return followers;
    }

// FestivalCreatedListener
    @Override
    @TransactionalEventListener
    public void onApplicationEvent(FestivalCreatedEvent event) {
        Festival festival = event.getFestival();
        (생략)
        List<User> followers = event.getFollowers();
        (생략)
    }
```

#### `read` 예약어로 인해 `Notification` Entity 테이블이 생성되지 않는 문제

* 발생한 예외

```java
// 런타임 Exception
org.hibernate.tool.schema.spi.CommandAcceptanceException: Error executing DDL "
    create table notifications (
        id bigint not null auto_increment,
        created_at datetime(6) not null,
        editor varchar(255) not null,
        expiration_time datetime(6) not null,
        read bit not null,
        title varchar(255) not null,
        user_id bigint not null,
        primary key (id)
    ) engine=InnoDB" via JDBC [You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'read bit not null,
        title varchar(255) not null,
        user_id bigint' at line 6]
```

* 예외가 발생한 코드

```java
// Notification (Entity)
    @Column(name = "read", nullable = false)
    private Boolean read;
```

* 원인 분석

>  read는 MySQL에서 예약어로 사용되는 키워드 중 하나이므로 컬럼 이름으로 사용하기에는 적합하지 않다. MySQL에서 키워드를 컬럼 이름으로 사용하려면 백틱(`)으로 묶어주어야 한다. -> 백틱으로 묶어주어 해결 -> 컬럼 이름으로 사용이 적합하지 않다하여 '변수명 짓기' 사이트 참고하여 컬럼명 재작성

* 수정한 코드

```java
// Notification (Entity)
@Column(name = "`read`", nullable = false)
private Boolean read;
```

* 재수정한 코드

```java
// Notification (Entity)
@Column(name = "rd", nullable = false)
private Boolean rd;
```