### PR TITLE
[Refactor] 클린코드 추가 내용 수정

### DIFF
--- a/src/main/java/com/sparta/lafesta/admin/controller/AdminController.java
+++ b/src/main/java/com/sparta/lafesta/admin/controller/AdminController.java
@@ -1,7 +1,7 @@
 package com.sparta.lafesta.admin.controller;
 
 import com.sparta.lafesta.admin.dto.OrganizerResponseDto;
-import com.sparta.lafesta.admin.service.AdminServiceImpl;
+import com.sparta.lafesta.admin.service.AdminService;
 import com.sparta.lafesta.common.dto.ApiResponseDto;
 import com.sparta.lafesta.common.security.UserDetailsImpl;
 import com.sparta.lafesta.festivalRequest.dto.FestivaRequestlResponseDto;
@@ -24,7 +24,7 @@ import java.util.List;
 @RequestMapping("/api/admin")
 @Tag(name = "관리자 기능 관련 API", description = "관리자 기능 관련 API 입니다.")
 public class AdminController {
-    private final AdminServiceImpl adminService;
+    private final AdminService adminService;
 
     @GetMapping("/users/organizer-requests")
     @Operation(summary = "주최사 가입 인증 요청 목록 조회", description = "주최사 가입 인증 요청한 목록을 전체 조회합니다.")

--- a/src/main/java/com/sparta/lafesta/comment/controller/CommentController.java
+++ b/src/main/java/com/sparta/lafesta/comment/controller/CommentController.java
@@ -2,7 +2,7 @@ package com.sparta.lafesta.comment.controller;
 
 import com.sparta.lafesta.comment.dto.CommentRequestDto;
 import com.sparta.lafesta.comment.dto.CommentResponseDto;
-import com.sparta.lafesta.comment.service.CommentServiceImpl;
+import com.sparta.lafesta.comment.service.CommentService;
 import com.sparta.lafesta.common.dto.ApiResponseDto;
 import com.sparta.lafesta.common.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,7 +25,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Tag(name = "페스티벌 리뷰 댓글 관련 API", description = "페스티벌 리뷰 댓글 관련 API 입니다.")
 public class CommentController {
-    private final CommentServiceImpl commentService;
+    private final CommentService commentService;
 
     @PostMapping("/festivals/{festivalId}/reviews/{reviewId}/comments")
     @Operation(summary = "페스티벌 리뷰 댓글 작성", description = "@PathVariable을 통해 reviewId를 받아와, 해당 위치에 페스티벌 리뷰에 댓글을 작성합니다. Dto를 통해 정보를 받아와 댓글을 생성할 때 해당 정보를 저장합니다.")

--- a/src/main/java/com/sparta/lafesta/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/sparta/lafesta/comment/service/CommentServiceImpl.java
@@ -8,7 +8,7 @@ import com.sparta.lafesta.common.exception.UnauthorizedException;
 import com.sparta.lafesta.like.commentLike.entity.CommentLike;
 import com.sparta.lafesta.like.commentLike.repository.CommentLikeRepository;
 import com.sparta.lafesta.review.entity.Review;
-import com.sparta.lafesta.review.service.ReviewServiceImpl;
+import com.sparta.lafesta.review.service.ReviewService;
 import com.sparta.lafesta.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class CommentServiceImpl implements CommentService {
     private final CommentRepository commentRepository;
-    private final ReviewServiceImpl reviewService;
+    private final ReviewService reviewService;
     private final CommentLikeRepository commentLikeRepository;
     @Autowired
     private TransactionTemplate transactionTemplate;
@@ -51,7 +51,7 @@ public class CommentServiceImpl implements CommentService {
         // user 권한 확인 예외처리 추후 추가 작성 예정
         Review review = reviewService.findReview(reviewId);
         return commentRepository.findAllByReview(review, pageable).stream()
-                .map(CommentResponseDto::new).collect(Collectors.toList());
+                .map(CommentResponseDto::new).toList();
     }
 
     // 댓글 내용 수정

--- a/src/main/java/com/sparta/lafesta/festival/dto/FestivalResponseDto.java
+++ b/src/main/java/com/sparta/lafesta/festival/dto/FestivalResponseDto.java
@@ -1,14 +1,12 @@
 package com.sparta.lafesta.festival.dto;
 
 import com.sparta.lafesta.common.s3.dto.FileOnS3Dto;
-import com.sparta.lafesta.common.s3.entity.FestivalFileOnS3;
 import com.sparta.lafesta.festival.entity.Festival;
 import com.sparta.lafesta.review.dto.ReviewResponseDto;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 public class FestivalResponseDto {
@@ -36,7 +34,7 @@ public class FestivalResponseDto {
         this.reservationPlace = festival.getReservationPlace();
         this.officialLink = festival.getOfficialLink();
         this.reviews = festival.getReviews().stream().
-                map(ReviewResponseDto::new).collect(Collectors.toList());
+                map(ReviewResponseDto::new).toList();
         this.files = festival.getFestivalFileOnS3s().stream().
                 map(FileOnS3Dto::new).toList();
         this.likeCnt = festival.getFestivalLikes().size();

--- a/src/main/java/com/sparta/lafesta/festival/service/FestivalService.java
+++ b/src/main/java/com/sparta/lafesta/festival/service/FestivalService.java
@@ -2,13 +2,14 @@ package com.sparta.lafesta.festival.service;
 
 import com.sparta.lafesta.festival.dto.FestivalRequestDto;
 import com.sparta.lafesta.festival.dto.FestivalResponseDto;
+import com.sparta.lafesta.festival.entity.Festival;
 import com.sparta.lafesta.notification.dto.ReminderDto;
 import com.sparta.lafesta.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
-import org.springframework.data.domain.Pageable;
 
 public interface FestivalService {
     /**
@@ -86,4 +87,11 @@ public interface FestivalService {
      * @return 페스티벌 리뷰 독려 알림을 보낼 페스티벌 가져오기 결과
      */
     List<ReminderDto> getReviewEncouragementReminders();
+
+    /**
+     * id로 페스티벌 가져오기
+     * @param festivalId 가져올 페스티벌의 id
+     * @return 가져온 페스티벌
+     */
+    Festival findFestival(Long festivalId);
 }

--- a/src/main/java/com/sparta/lafesta/festival/service/FestivalServiceImpl.java
+++ b/src/main/java/com/sparta/lafesta/festival/service/FestivalServiceImpl.java
@@ -30,7 +30,6 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Service
@@ -80,7 +79,7 @@ public class FestivalServiceImpl implements FestivalService {
     @Transactional(readOnly = true)
     public List<FestivalResponseDto> selectFestivals(Pageable pageable) {
         return festivalRepository.findAllBy(pageable).stream()
-                .map(FestivalResponseDto::new).collect(Collectors.toList());
+                .map(FestivalResponseDto::new).toList();
     }
 
 
@@ -244,7 +243,7 @@ public class FestivalServiceImpl implements FestivalService {
                     } else {
                         festivalStream = Stream.empty();
                     }
-                    return festivalStream.collect(Collectors.toList());
+                    return festivalStream.toList();
                 })
                 .flatMap(List::stream)
                 .toList();
@@ -253,7 +252,7 @@ public class FestivalServiceImpl implements FestivalService {
                 .map(festival -> new ReminderDto(festival, type)).toList();
     }
 
-    // 페스티벌 id로 페스티벌 찾기
+    // id로 페스티벌 가져오기
     public Festival findFestival(Long festivalId) {
         return festivalRepository.findById(festivalId).orElseThrow(() ->
                 new IllegalArgumentException("선택한 페스티벌은 존재하지 않습니다.")

--- a/src/main/java/com/sparta/lafesta/festivalRequest/controller/FestivalRequestController.java
+++ b/src/main/java/com/sparta/lafesta/festivalRequest/controller/FestivalRequestController.java
@@ -4,7 +4,7 @@ import com.sparta.lafesta.common.dto.ApiResponseDto;
 import com.sparta.lafesta.common.security.UserDetailsImpl;
 import com.sparta.lafesta.festivalRequest.dto.FestivaRequestlResponseDto;
 import com.sparta.lafesta.festivalRequest.dto.FestivalRequestRequestDto;
-import com.sparta.lafesta.festivalRequest.service.FestivalRequestServiceImpl;
+import com.sparta.lafesta.festivalRequest.service.FestivalRequestService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -22,7 +22,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Tag(name = "페스티벌 게시 요청 관련 API", description = "페스티벌 게시 요청 관련 API 입니다.")
 public class FestivalRequestController {
-    private final FestivalRequestServiceImpl festivalRequestService;
+    private final FestivalRequestService festivalRequestService;
 
     @PostMapping("/festival-requests")
     @Operation(summary = "페스티벌 게시 요청 등록", description = "페스티벌을 생성합니다. Dto를 통해 정보를 받아와 festival을 생성할 때 해당 정보를 저장합니다.")

--- a/src/main/java/com/sparta/lafesta/festivalRequest/service/FestivalRequestServiceImpl.java
+++ b/src/main/java/com/sparta/lafesta/festivalRequest/service/FestivalRequestServiceImpl.java
@@ -6,13 +6,11 @@ import com.sparta.lafesta.festivalRequest.dto.FestivalRequestRequestDto;
 import com.sparta.lafesta.festivalRequest.entity.FestivalRequest;
 import com.sparta.lafesta.festivalRequest.repository.FestivalRequestRepository;
 import com.sparta.lafesta.user.entity.User;
-import com.sparta.lafesta.user.entity.UserRoleEnum;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -37,7 +35,7 @@ public class FestivalRequestServiceImpl implements FestivalRequestService {
     @Transactional(readOnly = true)
     public List<FestivaRequestlResponseDto> selectFestivalRequests() {
         return festivalRequestRepository.findAllByOrderByCreatedAtDesc().stream()
-                .map(FestivaRequestlResponseDto::new).collect(Collectors.toList());
+                .map(FestivaRequestlResponseDto::new).toList();
     }
 
     // 페스티벌 게시 요청글 상세 조회

--- a/src/main/java/com/sparta/lafesta/notification/dto/ReminderDto.java
+++ b/src/main/java/com/sparta/lafesta/notification/dto/ReminderDto.java
@@ -11,7 +11,6 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 public class ReminderDto {
@@ -40,7 +39,7 @@ public class ReminderDto {
         this.festivalFollowUsersEmail = festival.getFestivalFollowers().stream()
                 .map(FestivalFollow::getFollowingFestivalUser)
                 .map(User::getEmail)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     // 타입별로 메일 제목 가져오기

--- a/src/main/java/com/sparta/lafesta/notification/service/NotificationService.java
+++ b/src/main/java/com/sparta/lafesta/notification/service/NotificationService.java
@@ -1,7 +1,7 @@
 package com.sparta.lafesta.notification.service;
 
 import com.sparta.lafesta.email.service.MailService;
-import com.sparta.lafesta.festival.service.FestivalServiceImpl;
+import com.sparta.lafesta.festival.service.FestivalService;
 import com.sparta.lafesta.notification.dto.ReminderDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -14,7 +14,7 @@ import java.util.List;
 public class NotificationService {
 
     private final MailService mailService;
-    private final FestivalServiceImpl festivalService;
+    private final FestivalService festivalService;
 
     // 매일 오전 9시마다 리마인더 알림 메일 발송
     @Scheduled(cron = "0 0 9 * * *")

--- a/src/main/java/com/sparta/lafesta/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/sparta/lafesta/review/dto/ReviewResponseDto.java
@@ -6,7 +6,6 @@ import com.sparta.lafesta.review.entity.Review;
 import lombok.Getter;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 public class ReviewResponseDto {
@@ -26,7 +25,7 @@ public class ReviewResponseDto {
         this.title = review.getTitle();
         this.content = review.getContent();
         this.comments = review.getComments().stream().
-                map(CommentResponseDto::new).collect(Collectors.toList());
+                map(CommentResponseDto::new).toList();
         this.files = review.getReviewFileOnS3s().stream().
                 map(FileOnS3Dto::new).toList();
         this.likeCnt = review.getReviewLikes().size();

--- a/src/main/java/com/sparta/lafesta/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/lafesta/review/service/ReviewService.java
@@ -2,12 +2,13 @@ package com.sparta.lafesta.review.service;
 
 import com.sparta.lafesta.review.dto.ReviewRequestDto;
 import com.sparta.lafesta.review.dto.ReviewResponseDto;
+import com.sparta.lafesta.review.entity.Review;
 import com.sparta.lafesta.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
-import org.springframework.data.domain.Pageable;
 
 public interface ReviewService {
     /**
@@ -70,4 +71,11 @@ public interface ReviewService {
      * @return 좋아요 취소 결과
      */
     ReviewResponseDto deleteReviewLike(Long reviewId, User user);
+
+    /**
+     * 리뷰 가져오기
+     * @param reviewId 가져올 리뷰의 id
+     * @return 가져온 리뷰
+     */
+    Review findReview(Long reviewId);
 }

--- a/src/main/java/com/sparta/lafesta/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/sparta/lafesta/review/service/ReviewServiceImpl.java
@@ -6,7 +6,7 @@ import com.sparta.lafesta.common.s3.entity.FileOnS3;
 import com.sparta.lafesta.common.s3.entity.ReviewFileOnS3;
 import com.sparta.lafesta.common.s3.repository.ReviewFileRepository;
 import com.sparta.lafesta.festival.entity.Festival;
-import com.sparta.lafesta.festival.service.FestivalServiceImpl;
+import com.sparta.lafesta.festival.service.FestivalService;
 import com.sparta.lafesta.like.reviewLike.entity.ReviewLike;
 import com.sparta.lafesta.like.reviewLike.repository.ReviewLikeRepository;
 import com.sparta.lafesta.review.dto.ReviewRequestDto;
@@ -25,14 +25,13 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ReviewServiceImpl implements ReviewService {
     //CRUD
     private final ReviewRepository reviewRepository;
-    private final FestivalServiceImpl festivalService;
+    private final FestivalService festivalService;
 
     //S3
     private final S3UploadService s3UploadService;
@@ -75,7 +74,7 @@ public class ReviewServiceImpl implements ReviewService {
         // user 권한 확인 예외처리 추후 추가 작성 예정
         Festival festival = festivalService.findFestival(festivalId);
         return reviewRepository.findAllByFestival(festival, pageable).stream()
-                .map(ReviewResponseDto::new).collect(Collectors.toList());
+                .map(ReviewResponseDto::new).toList();
     }
 
     // 리뷰 상세 조회
@@ -174,6 +173,7 @@ public class ReviewServiceImpl implements ReviewService {
     }
 
     // 리뷰 id로 리뷰 찾기
+    @Override
     public Review findReview(Long reviewId) {
         return reviewRepository.findById(reviewId).orElseThrow(() ->
                 new IllegalArgumentException("선택한 리뷰는 존재하지 않습니다.")


### PR DESCRIPTION
### 주입은 Service(인터페이스) > ServiceImpl(구현체)

- 모든 API의 Service를 인터페이스와 구현체로 나누던 중 궁금한 점이 생겨 질문 드립니다.
인터페이스와 구현체 중 어느 것을 Controller에서 @Autowired 해야 하며 그 이유는 무엇인가요? (출처: 슬랙 질문방)

<details>

    인터페이스에 의존하셔야합니다.TempService 인터페이스에 대한 구현체 TempServiceImpl이 있다고 생각해보겠습니다.TempController 에서는 인터페이스를 @Autowired 해도 되고, 구현체인 Impl 클래스를 @Autowired 해도 됩니다.하지만, 클라이언트의 요구로 인해 TempServiceImpl 클래스파일에 대해 큰 변경사항이 발생하여 두번째 버전의 TempService 구현체가 필요하다고 했을때, TempService에 대한 구현체를 따로 만들어야 합니다. 이를 위해 TempService를 구현한 TempServiceImpl2 구현체를 만들었습니다.이렇게 된다면,
    
    TempController에서 TempServiceImpl을 Autowired한 상황이라면, 클라이언트 코드인 TempController에서는 TempServiceImpl2 를 인젝션 받도록 "클라이언트 코드를 변경해야합니다".TempController에서 TempService 인터페이스를 Autowired 한 상황이라면, 클라이언트 코드의 변경 없이 TempServiceImpl 에 있는 @Service 애너테이션을 지우고, TempServiceImpl2 에 @Service 애너테이션만 추가하면 됩니다.즉, 클라이언트 코드에서는 변경할 점이 없습니다. 클라이언트 입장에서는 TempService 인터페이스에만 의존해 사용하면 되고, 그 구현체가 뭔지는 전혀 몰라도 됩니다. 관심도가 낮아지게 되는 것이죠추후, 첫번째 버전이었던 TempServiceImpl 로 돌아간다고 해도 @Service 애너테이션만 바꿔주고, 클라이언트에서는 코드 변경없이, 어떤 구현체가 들어올지도 모른채로 그냥 인터페이스에만 의존한채로 코드를 사용하면 됩니다.
    
    SOLID 원칙 중, D에 해당하는 Dependency Inversion Principal 에 적용되는 이야기이기도 합니다.의존관계 역전원칙으로, "
    
    **구현체보다는 인터페이스나 추상 클래스에 의존해야한다"**
    
    입니다.예를 들어, 아마 사용중이실 PasswordEncoder는 인터페이스 입니다. PasswordEncoder에 어떤 구현체가 들어올지도 모른채 해당 인터페이스를 @Autowired 받아 사용하고 계시겠죠.해당 인터페이스의 구현체는 BCryptPasswordEncoder, Argon2PasswordEncoder 매우 다양하지만, 어떤 것이 들어올지 모른채 클라이언트 입장에서 인터페이스만을 보고 사용하고 계실겁니다. (메서드명, 파라미터, 공식 설명 등을 참조하며). 구현체 내부의 동작방식은 다르겠지만, 해당 인터페이스의 메서드들이 목표하는 행위는 같습니다. 이는 SOLID의 L인 리스코프 치환 원칙을 지키는 것이구요.만약, 해당 인터페이스에 들어올 구현체를 명시해주어야 한다면 @Bean 등록을 통해 어떤 구현체를 넣어주고 싶은지 명시를 하긴 하지만, 사용할때는, PasswordEncoder만 @Autowired 받아서 사용합니다.아마 직접 만든 클래스파일이 아닌 경우 대부분의 경우 인터페이스를 @Autowired 하고 계시는 중일겁니다 !
    
</details>

### .stream을 사용해 List를 만들 때는 가급적 ‘.collect(Collectors.toList());’가 아닌 ‘toList();’ 사용 → 추가 수정 로직이 있는 경우에만 ‘.collect(Collectors.toList());’ 사용

- ‘.collect(Collectors.toList())’와 ‘toList()’의 차이
    
<details>

    ```java
    //.collect(Collectors.toList()) 사용
    return reviewRepository.findAllByFestival(festival, pageable).stream()
             .map(ReviewResponseDto::new).collect(Collectors.toList());
    ```
    
    ```java
    //.toList() 사용 (Java 16 이상):
    return reviewRepository.findAllByFestival(festival, pageable).stream()
             .map(ReviewResponseDto::new).toList();
    ```
    
    이 두 코드는 **`map`**을 통해 **`ReviewResponseDto`**로 변환된 요소들을 리스트로 수집하는 역할을 합니다. 차이점은 **`.toList()`**가 Java 16부터 추가된 메소드인 반면, **`.collect(Collectors.toList())`**는 이전 Java 버전에서 사용 가능한 구문입니다.
    
    Java 16 이전 버전에서는 **`.toList()`**를 사용할 수 없으므로 **`.collect(Collectors.toList())`**를 사용해야 합니다. 그러나 Java 16 이후 버전에서는 둘 중 어떤 것을 선택해도 상관없습니다. 코드의 가독성을 높이기 위해 Java 16 이상에서는 **`.toList()`**를 사용하는 것이 더 권장됩니다.
    
    `collect(Collectors.toList());`는 ArrayList를 반환해 수정이 가능하고
    
    `toList()`는 Collectors.UnmodifiableList 또는 Collectors.UnmodifiableRandomAccessList를 반환해 수정이 불가능합니다.
    
    따라서 조회 등 수정이 없는 경우 기본적으로 `toList()`로 사용하되 수정 로직이 추가로 있는 경우에만 `.collect(Collectors.toList());`를 사용!
    
    참고블로그: https://binux.tistory.com/146

</details>