### PR TITLE
[Front] 내 정보 조회 및 수정 페이지 기능 추가, 페스티벌 작성 페이지 완료

### DIFF
--- a/src/main/java/com/sparta/lafesta/user/controller/UserController.java
+++ b/src/main/java/com/sparta/lafesta/user/controller/UserController.java
@@ -190,7 +190,7 @@ public class UserController {
             @Parameter(description = "권한 확인을 위해 필요한 User 정보") @AuthenticationPrincipal UserDetailsImpl userDetails
     ) throws Exception {
         userService.sendMailAndCreateVerificationCodePassword(userDetails.getUser());
-        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "인증 메일이 발송되었습니다."));
+        return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "현재 저장된 이메일로 인증 메일이 발송되었습니다."));
     }
 
     // 인증코드 확인

--- a/src/main/java/com/sparta/lafesta/user/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/sparta/lafesta/user/dto/UserInfoResponseDto.java
@@ -14,6 +14,7 @@ public class UserInfoResponseDto {
     private String username;
     private String email;
     private String nickname;
+    private String introduce;
     private List<FileOnS3Dto> files;
 
     public UserInfoResponseDto(User user) {
@@ -24,5 +25,6 @@ public class UserInfoResponseDto {
         this.nickname = user.getNickname();
         this.files = user.getUserFileOnS3s().stream().
                 map(FileOnS3Dto::new).toList();
+        this.introduce = user.getIntroduce();
     }
 }

--- a/src/main/resources/static/css/mypage.css
+++ b/src/main/resources/static/css/mypage.css
@@ -18,8 +18,19 @@
     font-family: 'Roboto', sans-serif;
 }
 
-.profile-section img {
+/*.profile-section img {*/
+/*    width: 200px;*/
+/*    height: 200px;*/
+/*    border-radius: 50%;*/
+/*    overflow: hidden;*/
+/*    margin-bottom: 15px;*/
+/*}*/
+
+.circular-image {
+    width: 150px;
+    height: 150px;
     border-radius: 50%;
+    overflow: hidden;
     margin-bottom: 15px;
 }
 

--- a/src/main/resources/static/js/festival-post.js
+++ b/src/main/resources/static/js/festival-post.js
@@ -1,0 +1,140 @@
+// 페스티벌 작성
+function submitFestivalPost() {
+    // <form> 요소에서 데이터 가져오기
+    const title = document.querySelector('#titleInput').value;
+    const place = document.querySelector('#placeInput').value;
+    const content = document.querySelector('#contentInput').value;
+    const openDate = document.querySelector('#openDateInput').value;
+    const endDate = document.querySelector('#endDateInput').value;
+    const reservationOpenDate = document.querySelector('#reservationOpenDateInput').value;
+    const reservationPlace = document.querySelector('#reservationPlaceInput').value;
+    const officialLink = document.querySelector('#officialLinkInput').value;
+
+// 태그 값을 수집
+const tagInputs = document.querySelectorAll('#tags-input-container input[type="text"]');
+const tags = [];
+tagInputs.forEach(input => {
+    const tagValue = input.value.trim();
+    if (tagValue) {
+        tags.push({ title: tagValue });
+    }
+});
+
+// 이미지 파일을 수집
+    const imageFileInput = document.querySelector('#imageInput');
+    const imageFile = imageFileInput.files[0];
+
+// 위도, 경도 정보
+// URL에서 쿼리 문자열을 가져옵니다.
+    var queryString = window.location.search;
+
+// URLSearchParams를 사용하여 쿼리 문자열을 파싱합니다.
+    var queryParams = new URLSearchParams(queryString);
+    const latitude = queryParams.get('lat');
+    const longitude = queryParams.get('lng');
+
+    // 이미지 파일을 form-data에 추가
+    const formData = new FormData();
+    if (imageFile) {
+        formData.append('files', imageFile);
+    }
+
+    // DTO 객체 생성
+    const requestDto = {
+        title: title,
+        place: place,
+        content: content,
+        latitude: latitude,
+        longitude: longitude,
+        openDate: openDate,
+        endDate: endDate,
+        reservationOpenDate: reservationOpenDate,
+        reservationPlace: reservationPlace,
+        officialLink: officialLink,
+    };
+    console.log(requestDto);
+
+    // 태그 값이 있는 경우에만 Tags 속성을 추가
+    if (tags.length > 0) {
+        requestDto.tagList = tags;
+    }
+
+    // JSON 문자열을 Blob 객체로 변환하여 FormData에 추가
+    const jsonRequestDto = JSON.stringify(requestDto);
+    const jsonBlob = new Blob([jsonRequestDto], {type: 'application/json'});
+    formData.append('requestDto', jsonBlob);
+
+    // 서버로 데이터를 전송
+    $.ajax({
+        url: `/api/festivals`,
+        type: 'POST',
+        data: formData, // form-data 전송
+        contentType: false, // form-data는 contentType을 false로 설정
+        processData: false, // 이미지 파일을 전송할 때 false로 설정
+        success: function (data) {
+            alert(data.statusMessage);
+            // AJAX 요청이 완료되면 리다이렉트 수행
+            window.location.href = '/api/users/festivals-map';
+        },
+        error: function (err) {
+            alert(err.responseText.statusMessage);
+            console.log('Error:', err);
+        }
+    });
+}
+
+// 이미지 파일 미리보기
+// 파일 인풋 엘리먼트 가져오기
+const fileInput = document.getElementById('imageInput');
+
+// 이미지 미리보기를 위한 img 엘리먼트 가져오기
+const previewImage = document.getElementById('preview-image');
+
+// 파일 선택 시 이벤트 리스너 추가
+fileInput.addEventListener('change', function () {
+    // 선택한 파일 가져오기
+    const file = fileInput.files[0];
+
+    if (file) {
+        // 선택한 파일이 이미지인지 확인
+        if (file.type.startsWith('image/')) {
+            // 이미지 파일인 경우, 미리보기를 위해 FileReader 사용
+            const reader = new FileReader();
+
+            reader.onload = function (e) {
+                // 파일 불러오기가 완료되면 미리보기 이미지 업데이트
+                previewImage.src = e.target.result;
+            };
+
+            // 파일을 읽어옵니다.
+            reader.readAsDataURL(file);
+        } else {
+            alert('이미지 파일을 선택하세요.');
+            fileInput.value = ''; // 파일 선택 취소
+        }
+    }
+});
+
+let tagInputCount = 0;
+
+function addTagInput() {
+    const container = document.getElementById('tags-input-container'); // 인풋 필드를 포함할 컨테이너를 선택
+
+    // 새로운 인풋 필드를 생성합니다.
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'input-field';
+    input.placeholder = 'Tags';
+    input.style = 'width: 90px; margin-right: 5px';
+
+    // 인풋 필드에 고유한 ID를 할당하여 추적합니다.
+    input.id = `tagInput${tagInputCount}`;
+    tagInputCount++;
+
+    // 컨테이너에 인풋 필드를 추가합니다.
+    container.insertBefore(input, document.getElementById('addTagInput')); // 추가 버튼 위에 삽입
+}
+
+function redirectFestivalMap() {
+    window.location.href = '/api/users/festivals-map';
+}

--- a/src/main/resources/static/js/myedit.js
+++ b/src/main/resources/static/js/myedit.js
@@ -1,30 +1,349 @@
 $(document).ready(function () {
-    $("#submitButton").on("click", function (event) {
-        event.preventDefault();
+    $(document).ready(function () {
+        $.ajax({
+            url: `/api/users/info`,
+            type: 'GET',
+            success: function (data) {
+                console.log(data);
+                let html = `
+                    <div class="user-box">
+                        <input type="text" id="nicknameInput" required="" value="${data.nickname}">
+                        <label for="nicknameInput">Nickname</label>
+                    </div>
+                    <div class="right" style="margin-top: -60px"><a href="#" onclick="nicknameEdit()">수정</a></div>
+                     <div class="user-box">
+                        <input type="text" id="introduceInput" required="" value="${data.introduce}">
+                        <label for="introduceInput">Introduce</label>
+                    </div>
+                    <div class="right" style="margin-top: -60px"><a href="#" onclick="introduceEdit()">수정</a></div>
+                    <div class="user-box">
+                        <input type="email" id="emailInput" required="" value="${data.email}">
+                        <label for="emailInput">Email</label>
+                    </div>
+                        <button type="button" id="editEmailSendVerificationBtn" onclick="editEmailSendVerificationEmail()">인증메일 발송</button>
+                        <!-- 이메일 인증키 입력칸 (기본적으로 숨김) -->
+                        <div id="editEmailConfirmBox" style="display: none;">
+                            <input type="text" id="editEmailVerificationCodeInput" required>
+                            <label>인증코드</label><br>
+                            <button type="button" onclick="editEmailConfirmVerificationCode()">인증확인</button>
+                            <p id="timer1" style="color:white;">3:00</p>
+                        </div>
+                    <div class="right" style="margin-top: -60px"><a href="#" onclick="emailEdit()">수정</a></div>
+                    <div class="user-box">
+                    </div>
+                    <div class="user-box">
+                        <p style="top: -20px; left: 0; color: #03e9f4; font-size: 12px;">Password</p>
+                        <input type="password" id="currentPasswordInput" required="" placeholder="현재 비밀번호를 입력해주세요.">
+                        <input type="password" id="newPasswordInput" required="" placeholder="변경할 비밀번호를 입력해주세요">
+                    </div>
+                        <button type="button" id="sendVerificationBtn" onclick="editPasswordSendVerificationEmail()">(현재 비밀번호 분실 시) 인증메일 발송</button>
+                        <!-- 이메일 인증키 입력칸 (기본적으로 숨김) -->
+                        <div id="editPasswordConfirmBox" style="display: none;">
+                            <input type="text" id="editPasswordVerificationCodeInput" required>
+                            <label>인증코드</label><br>
+                            <button type="button" onclick="editPasswordConfirmVerificationCode('${data.email}')">인증확인</button>
+                            <p id="timer2" style="color:white;">3:00</p>
+                        </div>
+                    <div class="right" style="margin-top: -60px"><a href="#" onclick="passwordEdit()">수정</a></div>
+                    <div class="user-box">
+                        <p style="top: -20px; left: 0; color: #03e9f4; font-size: 12px;">Image</p>
+                        <p id="imageName" style="font-size: 16px; color: white">${data.files[0].keyName}</p>
+                        <div class="circular-image">
+                            <img id="preview" 
+                                src="${data.files[0].uploadFileUrl ? data.files[0].uploadFileUrl 
+                                : 'https://vignette.wikia.nocookie.net/the-sun-vanished/images/5/5d/Twitter-avi-gender-balanced-figure.png/revision/latest?cb=20180713020754'}" 
+                                alt="Image Preview" style="width: 100%; height: 100%; object-fit: cover;">
+                        </div>
+                        <input id="imageInput" type="file" accept="image/*" onchange="previewImage(this)">
+                    </div>
+                    <div class="right" style="margin-top: -60px"><a href="#" onclick="imageEdit()">수정</a></div>
+                `;
+                $('#profile-edit').html(html);
+            },
+            error: function (err) {
+                console.log('Error:', err);
+            }
+        });
+    });
 
-        const nickname = $("#nicknameInput").val();
+    $("#editEmailSendVerificationBtn").click(function () {
+        $("#editEmailConfirmBox").show();
+    });
 
-        if (nickname) {
-            $.ajax({
-                url: '/users/info',
-                type: 'PUT',
-                contentType: 'application/json',
-                data: JSON.stringify({
-                    nickname: nickname
-                }),
-                success: function (response) {
-                    if (response && response.status === 200) {
-                        alert("Nickname updated successfully.");
-                    } else {
-                        alert("Could not update nickname.");
-                    }
-                },
-                error: function (err) {
-                    alert("닉네임 수정요청이 완료되었습니다."); //임시ㅎㅎ
-                }
-            });
-        } else {
-            alert("Nickname cannot be empty.");
-        }
+    $("#editPasswordSendVerificationBtn").click(function () {
+        $("#editPasswordConfirmBox").show();
     });
 });
+
+// 이메일과 비밀번호 유효성 검사를 위한 정규 표현식
+const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/; // 최소 하나의 소문자, 하나의 대문자, 하나의 숫자가 포함되어 있고 최소 8자 이상
+
+// 타이머 변수
+let timer1;
+let timer2;
+let seconds = 180; // 3분
+
+// 카운트다운 타이머를 시작하는 함수
+function startCountdown(timer, timerElement) {
+    timer = setInterval(() => {
+        const minutes = Math.floor(seconds / 60);
+        const remainingSeconds = seconds % 60;
+        $(timerElement).text(`${minutes}:${remainingSeconds < 10 ? '0' : ''}${remainingSeconds}`);
+        if (seconds === 0) {
+            clearInterval(timer);
+            // // 인증과 관련된 UI 요소를 리셋
+            // $('#editEmailConfirmBox').hide();
+            // $('#editEmailSendVerificationBtn').show();
+            // $('#editPasswordConfirmBox').hide();
+            // $('#editPasswordSendVerificationBtn').show();
+            alert('인증 시간이 만료되었습니다. 인증 이메일을 다시 보내주세요.');
+        }
+        seconds--;
+    }, 1000);
+}
+
+// 타이머를 초기화하는 함수
+function resetTimer(timer) {
+    clearInterval(timer);
+    seconds = 180; // 3분
+    $('#timer1').text("3:00");
+    $('#timer2').text("3:00");
+}
+
+function previewImage(input) {
+    const preview = document.getElementById('preview');
+    const imageName = document.getElementById('imageName');
+
+    if (input.files && input.files[0]) {
+        const reader = new FileReader();
+
+        reader.onload = function (e) {
+            // 미리보기 이미지 업데이트
+            preview.src = e.target.result;
+            // 이미지 이름 업데이트
+            imageName.textContent = input.files[0].name;
+        };
+
+        reader.readAsDataURL(input.files[0]);
+    }
+}
+
+function nicknameEdit() {
+    const nickname = $("#nicknameInput").val();
+
+    if (nickname) {
+        $.ajax({
+            url: '/api/users/info/nickname',
+            type: 'PUT',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                nickname: nickname
+            }),
+            success: function (response) {
+                alert(response.statusMessage);
+            },
+            error: function (err) {
+                alert(err.statusMessage);
+            }
+        });
+    } else {
+        alert("Nickname cannot be empty.");
+    }
+}
+
+function introduceEdit() {
+    const introduce = $("#introduceInput").val();
+
+    if (introduce) {
+        $.ajax({
+            url: '/api/users/info/introduce',
+            type: 'PUT',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                introduce: introduce
+            }),
+            success: function (response) {
+                alert(response.statusMessage);
+            },
+            error: function (err) {
+                alert(err.statusMessage);
+            }
+        });
+    } else {
+        alert("Introduce cannot be empty.");
+    }
+}
+
+function emailEdit() {
+    const email = $("#emailInput").val();
+
+    if (email) {
+        $.ajax({
+            url: '/api/users/info/email',
+            type: 'PUT',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                email: email
+            }),
+            success: function (response) {
+                alert(response.statusMessage);
+            },
+            error: function (err) {
+                alert(err.statusMessage);
+            }
+        });
+    } else {
+        alert("Email cannot be empty.");
+    }
+}
+
+async function editEmailSendVerificationEmail() {
+    const email = $("#emailInput").val();
+    if (!emailRegex.test(email)) {
+        alert('유효한 이메일을 입력해주세요.');
+        return;
+    }
+
+    const response = await fetch('/api/users/mail-confirm', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+            email: email
+        })
+    });
+    if (response.ok) {
+        $('#editEmailConfirmBox').show();
+        $('#editEmailSendVerificationBtn').hide();
+        startCountdown(timer1, '#timer1'); // 타이머1 시작
+        const responseData = await response.json();
+        console.log(responseData.statusMessage);
+    } else {
+        $('#editEmailConfirmBox').hide();
+        $('#editEmailSendVerificationBtn').show();
+        const responseData = await response.json();
+        console.error(responseData.statusMessage);
+        alert(responseData.statusMessage);
+    }
+}
+
+async function editEmailConfirmVerificationCode() {
+    const email = $("#emailInput").val();
+    const verificationCode = $("#editEmailVerificationCodeInput").val();
+    await confirmVerificationCode(email, verificationCode);
+}
+
+async function editPasswordSendVerificationEmail() {
+    const response = await fetch('/api/users/mail-confirm-password', {
+        method: 'POST'
+    });
+    if (response.ok) {
+        $('#editPasswordConfirmBox').show();
+        $('#editPasswordSendVerificationBtn').hide();
+        startCountdown(timer2, '#timer2'); // 타이머2 시작
+        const responseData = await response.json();
+        console.log(responseData.statusMessage);
+    } else {
+        $('#editPasswordConfirmBox').hide();
+        $('#editPasswordSendVerificationBtn').show();
+        const responseData = await response.json();
+        console.error(responseData.statusMessage);
+        alert(responseData.statusMessage);
+    }
+}
+
+async function editPasswordConfirmVerificationCode(email) {
+    const verificationCode = $("#editPasswordVerificationCodeInput").val();
+    await confirmVerificationCode(email, verificationCode);
+}
+
+function passwordEdit() {
+    const currentPassword = $("#currentPasswordInput").val();
+    const newPassword = $("#newPasswordInput").val();
+
+    if (newPassword) {
+        if (!passwordRegex.test(newPassword)) {
+            alert('비밀번호는 적어도 하나의 영어 문자, 하나의 숫자, 하나의 특수 문자를 포함해야 하며, 적어도 8자 이상이어야 합니다.');
+            return;
+        }
+
+        $.ajax({
+            url: '/api/users/info/password',
+            type: 'PUT',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                currentPassword: currentPassword,
+                newPassword: newPassword
+            }),
+            success: function (response) {
+                alert(response.statusMessage);
+            },
+            error: function (err) {
+                alert(err.statusMessage);
+            }
+        });
+    } else {
+        alert("New Password cannot be empty.");
+    }
+}
+
+function imageEdit() {
+    // 이미지 파일을 수집
+    const imageFileInput = document.querySelector('#imageInput');
+    const imageFile = imageFileInput.files[0];
+
+    // 이미지 파일을 form-data에 추가
+    const formData = new FormData();
+    if (imageFile) {
+        formData.append('files', imageFile);
+    }
+
+    // 서버로 데이터를 전송
+    $.ajax({
+        url: `/api/users/info/image`,
+        type: 'PUT',
+        data: formData, // form-data 전송
+        contentType: false, // form-data는 contentType을 false로 설정
+        processData: false, // 이미지 파일을 전송할 때 false로 설정
+        success: function (data) {
+            alert(data.statusMessage);
+        },
+        error: function (err) {
+            alert(err.responseText.statusMessage);
+            console.log('Error:', err);
+        }
+    });
+}
+
+async function confirmVerificationCode(email, verificationCode) {
+    if (verificationCode) {
+        // 인증 확인
+        const verifyResponse = await fetch('/api/users/verify-code', {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                email: email,
+                verificationCode: verificationCode
+            })
+        });
+
+        if (verifyResponse.ok) {
+            resetTimer(timer1); // 타이머 초기화
+            resetTimer(timer2); // 타이머 초기화
+            const responseData = await verifyResponse.json();
+            console.log(responseData.statusMessage);
+            alert(responseData.statusMessage);
+            $('#editPasswordConfirmBox').hide();
+        } else {
+            const responseData = await verifyResponse.json();
+            console.error(responseData.statusMessage);
+            alert(responseData.statusMessage);
+        }
+    } else {
+        alert('인증 코드를 입력해주세요.');
+    }
+}

--- a/src/main/resources/templates/festival-post.html
+++ b/src/main/resources/templates/festival-post.html
@@ -15,185 +15,58 @@
 <body>
 <form id="festival-submit-form">
     <div style="margin-left: 30px">
-        <label for="festival-name">페스티벌 이름</label>
-        <input type="text" id="festival-name" name="festival-name" required><br><br>
+        <label for="titleInput">페스티벌 이름</label>
+        <input type="text" id="titleInput" name="titleInput" required><br><br>
 
         <div style="display: grid; grid-template-columns: repeat(2, 1fr); width: 100%">
             <div style="width: 90%">
-                <label for="start-datetime">시작 일시</label>
-                <input type="datetime-local" id="start-datetime" name="start-datetime" required><br><br>
+                <label for="openDateInput">시작 일시</label>
+                <input type="datetime-local" id="openDateInput" name="openDateInput" required><br><br>
             </div>
 
             <div style="width: 90%">
-                <label for="end-datetime">종료 일시</label>
-                <input type="datetime-local" id="end-datetime" name="end-datetime" required><br><br>
+                <label for="endDateInput">종료 일시</label>
+                <input type="datetime-local" id="endDateInput" name="endDateInput" required><br><br>
             </div>
         </div>
 
-        <label for="festival-place">페스티벌 장소</label>
-        <input type="text" id="festival-place" name="festival-place" required><br><br>
+        <label for="placeInput">페스티벌 장소</label>
+        <input type="text" id="placeInput" name="placeInput" required><br><br>
 
-        <label for="festival-description">페스티벌 설명</label>
-        <textarea id="festival-description" name="festival-description" required></textarea><br><br>
+        <label for="contentInput">페스티벌 설명</label>
+        <textarea id="contentInput" name="contentInput" required></textarea><br><br>
 
-        <label for="festival-image">페스티벌 이미지</label>
-        <input type="file" id="festival-image" name="festival-image" accept="image/*"><br>
+        <label for="imageInput">페스티벌 이미지</label>
+        <input type="file" id="imageInput" name="imageInput" accept="image/*"><br>
         <img id="preview-image" width="200" alt=""><br><br>
 
         <div style="display: grid; grid-template-columns: repeat(2, 1fr); width: 100%">
             <div style="width: 90%">
-                <label for="reservation-open-datetime">예매 오픈 일시</label>
-                <input type="datetime-local" id="reservation-open-datetime" name="reservation-open-datetime"
+                <label for="reservationOpenDateInput">예매 오픈 일시</label>
+                <input type="datetime-local" id="reservationOpenDateInput" name="reservationOpenDateInput"
                        required><br><br>
             </div>
 
             <div style="width: 90%">
-                <label for="reservation-place">예매처</label>
-                <input type="text" id="reservation-place" name="reservation-place" required><br><br>
+                <label for="reservationPlaceInput">예매처</label>
+                <input type="text" id="reservationPlaceInput" name="reservationPlaceInput" required><br><br>
             </div>
         </div>
-        <label for="festival-link">페스티벌 웹사이트/링크</label>
-        <input type="url" id="festival-link" name="festival-link" required><br><br>
-
+        <label for="officialLinkInput">페스티벌 웹사이트/링크</label>
+        <input type="url" id="officialLinkInput" name="officialLinkInput" required><br><br>
+        <label for="addTagInput">태그</label>
+        <div id="tags-input-container">
+            <a id="addTagInput" onclick="addTagInput()" style="color: #3b5998">추가</a>
+        </div>
+        <br><br>
         <input type="submit" id="festival-submit" name="festival-submit" onclick="submitFestivalPost()"
                value="페스티벌 정보 작성">
+        <input type="submit" onclick="redirectFestivalMap()" value="페스티벌 맵 돌아가기" style="background-color: crimson">
 
     </div>
 
 </form>
 
-<script>
-    // <form> 요소에서 데이터 가져오기
-    const title = document.getElementById('festival-name');
-    const place = document.getElementById('festival-place');
-    const content = document.getElementById('festival-description');
-    const openDate = document.getElementById('start-datetime');
-    const endDate = document.getElementById('end-datetime');
-    const reservationOpenDate = document.getElementById('reservation-open-datetime');
-    const reservationPlace = document.getElementById('reservation-place');
-    const officialLink = document.getElementById('festival-link');
-    // 이미지 파일을 가져옵니다.
-    const imageFile = document.getElementById('festival-image').files[0];
-
-    // 위도, 경도 정보
-    // URL에서 쿼리 문자열을 가져옵니다.
-    var queryString = window.location.search;
-
-    // URLSearchParams를 사용하여 쿼리 문자열을 파싱합니다.
-    var queryParams = new URLSearchParams(queryString);
-    const latitude = queryParams.get('lat');
-    const longitude = queryParams.get('lng');
-
-    let auth;
-
-    // 이미지 파일 미리보기
-    // 파일 인풋 엘리먼트 가져오기
-    const fileInput = document.getElementById('festival-image');
-
-    // 이미지 미리보기를 위한 img 엘리먼트 가져오기
-    const previewImage = document.getElementById('preview-image');
-
-    // 파일 선택 시 이벤트 리스너 추가
-    fileInput.addEventListener('change', function () {
-        // 선택한 파일 가져오기
-        const file = fileInput.files[0];
-
-        if (file) {
-            // 선택한 파일이 이미지인지 확인
-            if (file.type.startsWith('image/')) {
-                // 이미지 파일인 경우, 미리보기를 위해 FileReader 사용
-                const reader = new FileReader();
-
-                reader.onload = function (e) {
-                    // 파일 불러오기가 완료되면 미리보기 이미지 업데이트
-                    previewImage.src = e.target.result;
-                };
-
-                // 파일을 읽어옵니다.
-                reader.readAsDataURL(file);
-            } else {
-                alert('이미지 파일을 선택하세요.');
-                fileInput.value = ''; // 파일 선택 취소
-            }
-        }
-    });
-
-    $(document).ready(function () {
-        auth = 'Bearer ' + getToken();
-    });
-
-    // 쿠키에서 인증 토큰 가져오기
-    function getToken() {
-        let auth = getCookie('Authorization');
-
-        if (auth === undefined) {
-            return '';
-        }
-        // 쿠키 값을 디코딩하여 반환
-        return decodeURIComponent(auth);
-    }
-
-    // 쿠키 가져오는 함수
-    function getCookie(name) {
-        const value = `; ${document.cookie}`;
-        const parts = value.split(`; ${name}=`);
-        if (parts.length === 2) return parts.pop().split(';').shift();
-    }
-
-    // 페스티벌 작성
-    function submitFestivalPost() {
-        console.log("페스티벌 작성 시도")
-
-        // DTO 객체 생성
-        const requestDto = {
-            title: title.value,
-            place: place.value,
-            latitude: latitude,
-            longitude: longitude,
-            content: content.value,
-            openDate: openDate.value,
-            endDate: endDate.value,
-            reservationOpenDate: reservationOpenDate.value,
-            reservationPlace: reservationPlace.value,
-            officialLink: officialLink.value,
-        };
-
-        // FormData 객체를 생성하고 이미지 파일을 추가합니다.
-        // FormData 객체 생성
-        const formData = new FormData();
-
-        // 이미지 파일을 추가
-        formData.append('files', imageFile);
-
-        // JSON 문자열을 Blob 객체로 변환하여 FormData에 추가
-        const jsonRequestDto = JSON.stringify(requestDto);
-        const jsonBlob = new Blob([jsonRequestDto], {type: 'application/json'});
-        formData.append('requestDto', jsonBlob);
-
-
-
-        // 서버로 데이터를 전송
-        fetch(`/api/festivals`, {
-            method: 'POST',
-            headers: {
-                'Authorization': `${auth}`,
-                'Content-Type': `multipart/form-data; boundary=-----------MULTIPART_BOUNDARY-----------`,
-                // 'Content-Type': 'application/json',
-            },
-            body: formData,
-            // body: JSON.stringify(requestDto),
-        })
-            .then(response => {
-                return response.json(); // 응답을 JSON으로 파싱
-            })
-            .then(responseData => {
-                alert('페스티벌 작성 완료');
-            })
-            .catch(error => {
-                console.error('에러 발생:', error);
-            });
-    }
-
-</script>
+<script src="/js/festival-post.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/mypage-modify.html
+++ b/src/main/resources/templates/mypage-modify.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" as="font"
           href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,600,700|Material+Icons"/>
     <link rel="stylesheet" href="/css/slides.css">
+    <link rel="stylesheet" href="/css/mypage.css">
 
     <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/3.0.1/js.cookie.min.js"></script>
@@ -34,16 +35,15 @@
 <div class="login-box">
     <h2>Modify Profile</h2>
     <form id="modifyForm">
-        <div class="user-box">
-            <input type="text" id="nicknameInput" required="">
-            <label>Nickname</label>
+        <div id="profile-edit" class="user-box">
+
         </div>
-        <a href="#" id="submitButton">
+        <a href="/api/users/profile" id="submitButton">
             <span></span>
             <span></span>
             <span></span>
             <span></span>
-            수정하기
+            완료
         </a>
     </form>
 </div>

--- a/src/main/resources/templates/mypage.html
+++ b/src/main/resources/templates/mypage.html
@@ -56,6 +56,9 @@
                     <p><strong>Username</strong></p><p> ${data.username}</p>
                     <p><strong>Nickname</strong></p><p> ${data.nickname}</p>
                     <p><strong>Email</strong></p><p> ${data.email}</p>
+                    <p><strong>Introduce</strong></p><p> ${data.introduce}</p>
+                    <p><strong>Image</strong></p>
+                    <img width="200px" src="${data.files[0].uploadFileUrl}" alt="Image Description">
                 `;
                 $('#profile').html(html);
             },

--- a/src/main/resources/templates/mypage.html
+++ b/src/main/resources/templates/mypage.html
@@ -58,7 +58,7 @@
                     <p><strong>Email</strong></p><p> ${data.email}</p>
                     <p><strong>Introduce</strong></p><p> ${data.introduce}</p>
                     <p><strong>Image</strong></p>
-                    <img width="200px" src="${data.files[0].uploadFileUrl}" alt="Image Description">
+                    <img width="200px" src="${data.files[0].uploadFileUrl ? data.files[0].uploadFileUrl : 'https://vignette.wikia.nocookie.net/the-sun-vanished/images/5/5d/Twitter-avi-gender-balanced-figure.png/revision/latest?cb=20180713020754'}" alt="Image Description">
                 `;
                 $('#profile').html(html);
             },

--- a/src/main/resources/templates/mypage.html
+++ b/src/main/resources/templates/mypage.html
@@ -58,7 +58,11 @@
                     <p><strong>Email</strong></p><p> ${data.email}</p>
                     <p><strong>Introduce</strong></p><p> ${data.introduce}</p>
                     <p><strong>Image</strong></p>
-                    <img width="200px" src="${data.files[0].uploadFileUrl ? data.files[0].uploadFileUrl : 'https://vignette.wikia.nocookie.net/the-sun-vanished/images/5/5d/Twitter-avi-gender-balanced-figure.png/revision/latest?cb=20180713020754'}" alt="Image Description">
+                    <div class="circular-image">
+                    <img src="${data.files[0].uploadFileUrl ? data.files[0].uploadFileUrl
+                    : 'https://vignette.wikia.nocookie.net/the-sun-vanished/images/5/5d/Twitter-avi-gender-balanced-figure.png/revision/latest?cb=20180713020754'}"
+                    alt="Image Description" style="width: 100%; height: 100%; object-fit: cover;">
+                    </div>
                 `;
                 $('#profile').html(html);
             },


### PR DESCRIPTION
## 관련 Issue

<!-- 해당 Pull Request와 관련된 Issue를 적습니다. -->

* #87 

## 변경 사항

<!-- 이 Pull Request에서 어떤 점이 변경되었는지 간단하게 설명해주세요.
* 프로필 조회 내용 추가
* 프로필 수정 페이지 완료
* 페스티벌 작성 - 맵에서 위치 결정 -> 작성 버튼 -> 작성 페이지 연결 완료

## Todo List

<!-- 이번 Pull Request 작업에서 아직 처리하지 못한 작업이나  
    추후에 해결해야 될 문제들을 기입해 주세요 -->  

* 페스티벌 맵에서 작성된 페스티벌 보이기
<img width="1271" alt="스크린샷 2023-09-11 031136" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/34998882-d801-4a72-b297-0f86326e4850">

* 페스티벌 수정, 삭제 추가
<img width="1262" alt="스크린샷 2023-09-11 031149" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/e074e6ef-a6ad-46b6-905f-c28e0be1cc92">

* 유저 탈퇴 기능 추가
<img width="1260" alt="스크린샷 2023-09-11 031211" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/f7fa65d0-f5f4-46be-bfc9-97d4f51949a3">
<img width="1255" alt="스크린샷 2023-09-11 031224" src="https://github.com/LaFesta7/LikeFesta/assets/131599243/22a99980-4137-4b67-9896-5491eb5438e2">


## Check List

<!-- 기능 구현을 다 했다면? --> 

- [x] 브라우저 체크완료