### PR TITLE
Hoxfix/96/cd 수정

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -35,6 +35,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
       # (2) JDK 17 세팅
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-    steps:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
## 관련 Issue

#96 

## 변경 사항

- node 버전 지정 코드 추가

## Todo List

<!-- 이번 Pull Request 작업에서 아직 처리하지 못한 작업이나  
    추후에 해결해야 될 문제들을 기입해 주세요 -->  
<!-- 이번 Pull Request 작업에서 아직 처리하지 못한 작업이나  
    추후에 해결해야 될 문제들을 기입해 주세요 -->  

* cd 구현

## 트러블 슈팅

<!-- 있었던 오류나 발생했던 예외에 대해서 기록해 보세요 -->  

CD 구현기능을 포함한 코드를 main에 push 했는데 1 error and 2 warnings 발

발생한 에러

```
[Deploy](https://github.com/LaFesta7/LikeFesta/actions/runs/6156874771/job/16706434810#step:8:30)
Process completed with exit code 254.

[Deploy](https://github.com/LaFesta7/LikeFesta/actions/runs/6156874771/job/16706434810)
The following actions uses node12 which is deprecated and will be forced to run on node16: aws-actions/configure-aws-credentials@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

[Deploy](https://github.com/LaFesta7/LikeFesta/actions/runs/6156874771/job/16706434810#step:7:25)
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

원인 분석

> GitHub Actions 는 node.js 의 12버전을 사용중이지만
우분투를 사용한 해당 cd가 node.js 16을 사용할 것이라고 경고하므로 
사용하려는 Node.js 버전을 명시적으로 지정하였다.

수정한 코드

```
    steps:
      - name: Set up Node.js
        uses: actions/setup-node@v2
        with:
          node-version: '16'
```